### PR TITLE
adding feature to try another IDV provider if verification with current IDV provider has failed

### DIFF
--- a/src/routes/sessions.js
+++ b/src/routes/sessions.js
@@ -5,6 +5,7 @@ import {
   createIdvSession,
   createIdvSessionV2,
   createIdvSessionV3,
+  setIdvProvider,
   refreshOnfidoToken,
   createOnfidoCheckEndpoint,
   refund,
@@ -19,6 +20,7 @@ router.post("/:_id/paypal-order", createPayPalOrder);
 // router.post("/:_id/idv-session", createIdvSession);
 router.post("/:_id/idv-session/v2", createIdvSessionV2);
 router.post("/:_id/idv-session/v3", createIdvSessionV3);
+router.get("/:_id/set-idv-provider/:idvProvider", setIdvProvider);
 router.post("/:_id/idv-session/refund", refund);
 router.post("/:_id/idv-session/refund/v2", refundV2);
 router.post("/:_id/idv-session/onfido/token", refreshOnfidoToken);

--- a/src/services/session-status.js
+++ b/src/services/session-status.js
@@ -282,6 +282,12 @@ async function getSessionStatusV2(req, res) {
       return res.status(404).json({ error: "Session not found" });
     }
 
+    // not required
+    // this is to provide direct status query
+    // when more than 1 idv sessions are done in 1 session
+    const provider = req.query.provider;
+    if(provider) session.idvProvider = provider;
+
     if (session.idvProvider === "veriff") {
       if (!session.sessionId) {
         return res.status(200).json({

--- a/src/services/sessions/endpoints.js
+++ b/src/services/sessions/endpoints.js
@@ -574,6 +574,11 @@ async function setIdvProvider(req, res) {
     const _id = req.params._id;
     const idvProvider = req.params.idvProvider;
 
+    // check the idvProvider is either veriff or onfido
+    if (!(idvProvider === "onfido" || idvProvider === "veriff")) {
+      return res.status(400).json({ error: "IDV provider can only be either onfido or veriff" });
+    }
+
     let objectId = null;
 
     try {


### PR DESCRIPTION
added `setIdvProvider`
tweaked `setSessionStatusV2` to allow setting `provider` from request param.