### PR TITLE
feat(zk-passport): $3 paid session tier

### DIFF
--- a/src/constants/misc.ts
+++ b/src/constants/misc.ts
@@ -119,6 +119,8 @@ export const idvSessionUSDPrice = 5.0;
 
 export const amlSessionUSDPrice = 1;
 
+export const zkPassportSessionUSDPrice = 3.0;
+
 export const defaultActionId = 123456789;
 
 export const kycIssuerAddress =
@@ -214,3 +216,4 @@ export const PAYMENT_SERVICE_GOV_ID_VERIFICATION = ethers.utils.keccak256(ethers
 export const PAYMENT_SERVICE_CLEAN_HANDS_VERIFICATION = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('human_id_clean_hands_verification'))
 export const PAYMENT_SERVICE_PHONE_VERIFICATION = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('human_id_phone_verification'))
 export const PAYMENT_SERVICE_BIOMETRICS_VERIFICATION = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('human_id_biometrics_verification'))
+export const PAYMENT_SERVICE_ZK_PASSPORT_VERIFICATION = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('human_id_zk_passport_verification'))

--- a/src/init.ts
+++ b/src/init.ts
@@ -30,6 +30,8 @@ import {
   BiometricsNullifierAndCredsSchema,
   ZkPassportNullifierAndCredsSchema,
   SandboxZkPassportNullifierAndCredsSchema,
+  zkPassportSessionSchema,
+  sandboxZkPassportSessionSchema,
   DailyVerificationCountSchema,
   DailyVerificationDeletionsSchema,
   VerificationCollisionMetadataSchema,
@@ -81,6 +83,8 @@ import {
   IBiometricsNullifierAndCreds,
   IZkPassportNullifierAndCreds,
   ISandboxZkPassportNullifierAndCreds,
+  IZkPassportSession,
+  ISandboxZkPassportSession,
   IVerificationCollisionMetadata,
   IAmlChecksSession,
   ISandboxAmlChecksSession,
@@ -342,6 +346,16 @@ async function initializeMongoDb() {
     SandboxZkPassportNullifierAndCredsSchema
   );
 
+  const ZkPassportSession = mongoose.model(
+    "ZkPassportSession",
+    zkPassportSessionSchema
+  );
+
+  const SandboxZkPassportSession = mongoose.model(
+    "SandboxZkPassportSession",
+    sandboxZkPassportSessionSchema
+  );
+
   const DailyVerificationCount = mongoose.model(
     "DailyVerificationCount",
     DailyVerificationCountSchema
@@ -502,6 +516,8 @@ async function initializeMongoDb() {
     BiometricsNullifierAndCreds,
     ZkPassportNullifierAndCreds,
     SandboxZkPassportNullifierAndCreds,
+    ZkPassportSession,
+    SandboxZkPassportSession,
     DailyVerificationCount,
     DailyVerificationDeletions,
     VerificationCollisionMetadata,
@@ -557,6 +573,8 @@ let UserVerifications: Model<IUserVerifications>,
   BiometricsNullifierAndCreds: Model<IBiometricsNullifierAndCreds>,
   ZkPassportNullifierAndCreds: Model<IZkPassportNullifierAndCreds>,
   SandboxZkPassportNullifierAndCreds: Model<ISandboxZkPassportNullifierAndCreds>,
+  ZkPassportSession: Model<IZkPassportSession>,
+  SandboxZkPassportSession: Model<ISandboxZkPassportSession>,
   DailyVerificationCount: Model<IDailyVerificationCount>,
   DailyVerificationDeletions: Model<IDailyVerificationDeletions>,
   VerificationCollisionMetadata: Model<IVerificationCollisionMetadata>,
@@ -610,6 +628,8 @@ initializeMongoDb().then((result) => {
     BiometricsNullifierAndCreds = result.BiometricsNullifierAndCreds;
     ZkPassportNullifierAndCreds = result.ZkPassportNullifierAndCreds;
     SandboxZkPassportNullifierAndCreds = result.SandboxZkPassportNullifierAndCreds;
+    ZkPassportSession = result.ZkPassportSession;
+    SandboxZkPassportSession = result.SandboxZkPassportSession;
     DailyVerificationCount = result.DailyVerificationCount;
     DailyVerificationDeletions = result.DailyVerificationDeletions;
     VerificationCollisionMetadata = result.VerificationCollisionMetadata;
@@ -670,6 +690,7 @@ function getRouteHandlerConfig(environment: "sandbox" | "live"): SandboxVsLiveKY
       AMLChecksSessionModel: SandboxAMLChecksSession,
       CleanHandsNullifierAndCredsModel: SandboxCleanHandsNullifierAndCreds,
       ZkPassportNullifierAndCredsModel: SandboxZkPassportNullifierAndCreds,
+      ZkPassportSessionModel: SandboxZkPassportSession,
       SanctionsResultModel: SanctionsResult,
       PaymentRedemptionModel: SandboxPaymentRedemption,
       PaymentSecretModel: SandboxPaymentSecret,
@@ -704,6 +725,7 @@ function getRouteHandlerConfig(environment: "sandbox" | "live"): SandboxVsLiveKY
     AMLChecksSessionModel: AMLChecksSession,
     CleanHandsNullifierAndCredsModel: CleanHandsNullifierAndCreds,
     ZkPassportNullifierAndCredsModel: ZkPassportNullifierAndCreds,
+    ZkPassportSessionModel: ZkPassportSession,
     SanctionsResultModel: SanctionsResult,
     issuerPrivateKey: process.env.HOLONYM_ISSUER_PRIVKEY!,
     cleanHandsIssuerPrivateKey: process.env.HOLONYM_ISSUER_CLEAN_HANDS_PRIVKEY!,
@@ -741,6 +763,8 @@ export {
   BiometricsNullifierAndCreds,
   ZkPassportNullifierAndCreds,
   SandboxZkPassportNullifierAndCreds,
+  ZkPassportSession,
+  SandboxZkPassportSession,
   DailyVerificationCount,
   DailyVerificationDeletions,
   VerificationCollisionMetadata,

--- a/src/routes/zk-passport.ts
+++ b/src/routes/zk-passport.ts
@@ -4,8 +4,8 @@ import {
   verifyAndIssueSandbox,
 } from "../services/zk-passport/verify-and-issue.js";
 import {
-  postZkPassportSessionV2Prod,
-  postZkPassportSessionV2Sandbox,
+  postZkPassportSessionProd,
+  postZkPassportSessionSandbox,
   getZkPassportSessionProd,
   getZkPassportSessionSandbox,
   refundZkPassportSessionProd,
@@ -14,14 +14,14 @@ import {
 
 const prodRouter = express.Router();
 
-prodRouter.post("/sessions/v2", postZkPassportSessionV2Prod);
+prodRouter.post("/sessions", postZkPassportSessionProd);
 prodRouter.get("/sessions/:sid", getZkPassportSessionProd);
 prodRouter.post("/sessions/:sid/refund", refundZkPassportSessionProd);
 prodRouter.post("/verify-and-issue", verifyAndIssueProd);
 
 const sandboxRouter = express.Router();
 
-sandboxRouter.post("/sessions/v2", postZkPassportSessionV2Sandbox);
+sandboxRouter.post("/sessions", postZkPassportSessionSandbox);
 sandboxRouter.get("/sessions/:sid", getZkPassportSessionSandbox);
 sandboxRouter.post("/sessions/:sid/refund", refundZkPassportSessionSandbox);
 sandboxRouter.post("/verify-and-issue", verifyAndIssueSandbox);

--- a/src/routes/zk-passport.ts
+++ b/src/routes/zk-passport.ts
@@ -3,13 +3,27 @@ import {
   verifyAndIssueProd,
   verifyAndIssueSandbox,
 } from "../services/zk-passport/verify-and-issue.js";
+import {
+  postZkPassportSessionV2Prod,
+  postZkPassportSessionV2Sandbox,
+  getZkPassportSessionProd,
+  getZkPassportSessionSandbox,
+  refundZkPassportSessionProd,
+  refundZkPassportSessionSandbox,
+} from "../services/zk-passport/sessions.js";
 
 const prodRouter = express.Router();
 
+prodRouter.post("/sessions/v2", postZkPassportSessionV2Prod);
+prodRouter.get("/sessions/:sid", getZkPassportSessionProd);
+prodRouter.post("/sessions/:sid/refund", refundZkPassportSessionProd);
 prodRouter.post("/verify-and-issue", verifyAndIssueProd);
 
 const sandboxRouter = express.Router();
 
+sandboxRouter.post("/sessions/v2", postZkPassportSessionV2Sandbox);
+sandboxRouter.get("/sessions/:sid", getZkPassportSessionSandbox);
+sandboxRouter.post("/sessions/:sid/refund", refundZkPassportSessionSandbox);
 sandboxRouter.post("/verify-and-issue", verifyAndIssueSandbox);
 
 export default prodRouter;

--- a/src/routes/zk-passport.ts
+++ b/src/routes/zk-passport.ts
@@ -8,6 +8,8 @@ import {
   postZkPassportSessionSandbox,
   getZkPassportSessionProd,
   getZkPassportSessionSandbox,
+  listZkPassportSessionsProd,
+  listZkPassportSessionsSandbox,
   refundZkPassportSessionProd,
   refundZkPassportSessionSandbox,
 } from "../services/zk-passport/sessions.js";
@@ -15,6 +17,7 @@ import {
 const prodRouter = express.Router();
 
 prodRouter.post("/sessions", postZkPassportSessionProd);
+prodRouter.get("/sessions", listZkPassportSessionsProd);
 prodRouter.get("/sessions/:sid", getZkPassportSessionProd);
 prodRouter.post("/sessions/:sid/refund", refundZkPassportSessionProd);
 prodRouter.post("/verify-and-issue", verifyAndIssueProd);
@@ -22,6 +25,7 @@ prodRouter.post("/verify-and-issue", verifyAndIssueProd);
 const sandboxRouter = express.Router();
 
 sandboxRouter.post("/sessions", postZkPassportSessionSandbox);
+sandboxRouter.get("/sessions", listZkPassportSessionsSandbox);
 sandboxRouter.get("/sessions/:sid", getZkPassportSessionSandbox);
 sandboxRouter.post("/sessions/:sid/refund", refundZkPassportSessionSandbox);
 sandboxRouter.post("/verify-and-issue", verifyAndIssueSandbox);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -983,11 +983,6 @@ const zkPassportSessionSchema = new Schema<IZkPassportSession>({
     type: Number,
     required: false,
   },
-  numAttempts: {
-    type: Number,
-    required: false,
-    default: 0,
-  },
   failureReason: {
     type: String,
     required: false,
@@ -1014,11 +1009,6 @@ const sandboxZkPassportSessionSchema = new Schema<ISandboxZkPassportSession>({
   chainId: {
     type: Number,
     required: false,
-  },
-  numAttempts: {
-    type: Number,
-    required: false,
-    default: 0,
   },
   failureReason: {
     type: String,

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -31,6 +31,8 @@ import {
   IBiometricsNullifierAndCreds,
   IZkPassportNullifierAndCreds,
   ISandboxZkPassportNullifierAndCreds,
+  IZkPassportSession,
+  ISandboxZkPassportSession,
   IEncryptedNullifiers,
   ISandboxEncryptedNullifiers,
   IDailyVerificationCount,
@@ -965,6 +967,75 @@ const SandboxZkPassportNullifierAndCredsSchema = new Schema<ISandboxZkPassportNu
   },
 });
 
+// ZkPassportSession binds a $3 payment commitment to a zkPassport verification
+// attempt. The session only exists post-payment; status lifecycle is
+// IN_PROGRESS → { ISSUED | VERIFICATION_FAILED | REFUNDED }. Refunds are
+// allowed only when status === VERIFICATION_FAILED (ISSUED sessions have had
+// their redemption consumed).
+const zkPassportSessionSchema = new Schema<IZkPassportSession>({
+  sigDigest: String,
+  status: String,
+  paymentCommitment: {
+    type: String,
+    required: false,
+  },
+  chainId: {
+    type: Number,
+    required: false,
+  },
+  numAttempts: {
+    type: Number,
+    required: false,
+    default: 0,
+  },
+  failureReason: {
+    type: String,
+    required: false,
+  },
+  refundTxHashes: {
+    type: [String],
+    required: false,
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now,
+  },
+});
+zkPassportSessionSchema.index({ sigDigest: 1 });
+zkPassportSessionSchema.index({ paymentCommitment: 1 }, { unique: true, sparse: true });
+
+const sandboxZkPassportSessionSchema = new Schema<ISandboxZkPassportSession>({
+  sigDigest: String,
+  status: String,
+  paymentCommitment: {
+    type: String,
+    required: false,
+  },
+  chainId: {
+    type: Number,
+    required: false,
+  },
+  numAttempts: {
+    type: Number,
+    required: false,
+    default: 0,
+  },
+  failureReason: {
+    type: String,
+    required: false,
+  },
+  refundTxHashes: {
+    type: [String],
+    required: false,
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now,
+  },
+});
+sandboxZkPassportSessionSchema.index({ sigDigest: 1 });
+sandboxZkPassportSessionSchema.index({ paymentCommitment: 1 }, { unique: true, sparse: true });
+
 // To allow the user to persist a nullifier so that they can request their
 // signed credentials in more than one browser session.
 const EncryptedNullifiersSchema = new Schema<IEncryptedNullifiers>({
@@ -1594,6 +1665,8 @@ export {
   BiometricsNullifierAndCredsSchema,
   ZkPassportNullifierAndCredsSchema,
   SandboxZkPassportNullifierAndCredsSchema,
+  zkPassportSessionSchema,
+  sandboxZkPassportSessionSchema,
   DailyVerificationCountSchema,
   DailyVerificationDeletionsSchema,
   VerificationCollisionMetadataSchema,

--- a/src/services/payments/endpoints.ts
+++ b/src/services/payments/endpoints.ts
@@ -18,7 +18,12 @@ import {
 import { getRouteHandlerConfig } from "../../init.js";
 import { SandboxVsLiveKYCRouteHandlerConfig } from "../../types.js";
 import { pinoOptions, logger } from "../../utils/logger.js";
-import { idvSessionUSDPrice, humanIDPaymentsContractAddresses } from "../../constants/misc.js";
+import {
+  idvSessionUSDPrice,
+  zkPassportSessionUSDPrice,
+  humanIDPaymentsContractAddresses,
+  PAYMENT_SERVICE_ZK_PASSPORT_VERIFICATION,
+} from "../../constants/misc.js";
 
 const paymentsLogger = logger.child({
   base: {
@@ -53,8 +58,15 @@ function createCreatePaymentParamsRouteHandler(config: SandboxVsLiveKYCRouteHand
       }
       const timestamp = Math.floor(Date.now() / 1000);
 
+      // Per-service USD price. Default to idvSessionUSDPrice (gov-id/KYC price)
+      // for unrecognized services to preserve legacy behavior.
+      let usdPrice = idvSessionUSDPrice;
+      if (service.toLowerCase() === PAYMENT_SERVICE_ZK_PASSPORT_VERIFICATION.toLowerCase()) {
+        usdPrice = zkPassportSessionUSDPrice;
+      }
+
       // Calculate price in token
-      const amount = await calculatePriceInToken(idvSessionUSDPrice, chainIdNum);
+      const amount = await calculatePriceInToken(usdPrice, chainIdNum);
 
       // Generate signature
       const signature = await generatePaymentSignature(

--- a/src/services/zk-passport/sessions.ts
+++ b/src/services/zk-passport/sessions.ts
@@ -174,6 +174,53 @@ export async function postZkPassportSessionSandbox(req: Request, res: Response) 
 }
 
 /**
+ * GET /zk-passport/sessions?sigDigest=<holoUserId>
+ *
+ * List the caller's zkPassport sessions. Used by the Prereqs page so a user
+ * with an existing IN_PROGRESS or ISSUED session can resume rather than
+ * being forced back through /pay.
+ */
+function createListZkPassportSessionsHandler(config: SandboxVsLiveKYCRouteHandlerConfig) {
+  return async (req: Request, res: Response) => {
+    try {
+      const sigDigest = req.query?.sigDigest;
+      if (!sigDigest || typeof sigDigest !== "string") {
+        return res.status(400).json({ error: "sigDigest is required" });
+      }
+
+      const sessions = await config.ZkPassportSessionModel.find({ sigDigest })
+        .sort({ createdAt: -1 })
+        .lean()
+        .exec();
+
+      return res.status(200).json(
+        sessions.map((s) => ({
+          _id: s._id,
+          status: s.status,
+          chainId: s.chainId,
+          failureReason: s.failureReason,
+          createdAt: s.createdAt,
+        })),
+      );
+    } catch (err: any) {
+      zkPassportSessionsLogger.error(
+        { error: makeUnknownErrorLoggable(err) },
+        "GET /zk-passport/sessions error",
+      );
+      return res.status(500).json({ error: "An unknown error occurred" });
+    }
+  };
+}
+
+export async function listZkPassportSessionsProd(req: Request, res: Response) {
+  return createListZkPassportSessionsHandler(getRouteHandlerConfig("live"))(req, res);
+}
+
+export async function listZkPassportSessionsSandbox(req: Request, res: Response) {
+  return createListZkPassportSessionsHandler(getRouteHandlerConfig("sandbox"))(req, res);
+}
+
+/**
  * GET /zk-passport/sessions/:sid
  *
  * Returns session status. Used by the frontend to gate access to verify/

--- a/src/services/zk-passport/sessions.ts
+++ b/src/services/zk-passport/sessions.ts
@@ -29,7 +29,7 @@ const zkPassportSessionsLogger = logger.child({
 const MAX_ZK_PASSPORT_SESSIONS_PER_USER = 10;
 
 /**
- * POST /zk-passport/sessions/v2
+ * POST /zk-passport/sessions
  *
  * Creates a zkPassport verification session bound to a paid commitment.
  * The session only exists post-payment: `reserveRedemption` validates the
@@ -42,7 +42,7 @@ const MAX_ZK_PASSPORT_SESSIONS_PER_USER = 10;
  * Body: { holoUserId, paymentSecret, paymentChainId }
  * Returns: { session } with _id as the sid.
  */
-function createPostZkPassportSessionV2Handler(config: SandboxVsLiveKYCRouteHandlerConfig) {
+function createPostZkPassportSessionHandler(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
     let reservationToken: string | null = null;
 
@@ -115,7 +115,6 @@ function createPostZkPassportSessionV2Handler(config: SandboxVsLiveKYCRouteHandl
         status: sessionStatusEnum.IN_PROGRESS,
         paymentCommitment: reservation.commitment,
         chainId: chainIdNum,
-        numAttempts: 0,
       });
       await session.save();
 
@@ -159,19 +158,19 @@ function createPostZkPassportSessionV2Handler(config: SandboxVsLiveKYCRouteHandl
 
       zkPassportSessionsLogger.error(
         { error: makeUnknownErrorLoggable(err) },
-        "POST /zk-passport/sessions/v2 error",
+        "POST /zk-passport/sessions error",
       );
       return res.status(500).json({ error: "An unknown error occurred" });
     }
   };
 }
 
-export async function postZkPassportSessionV2Prod(req: Request, res: Response) {
-  return createPostZkPassportSessionV2Handler(getRouteHandlerConfig("live"))(req, res);
+export async function postZkPassportSessionProd(req: Request, res: Response) {
+  return createPostZkPassportSessionHandler(getRouteHandlerConfig("live"))(req, res);
 }
 
-export async function postZkPassportSessionV2Sandbox(req: Request, res: Response) {
-  return createPostZkPassportSessionV2Handler(getRouteHandlerConfig("sandbox"))(req, res);
+export async function postZkPassportSessionSandbox(req: Request, res: Response) {
+  return createPostZkPassportSessionHandler(getRouteHandlerConfig("sandbox"))(req, res);
 }
 
 /**
@@ -213,7 +212,6 @@ function createGetZkPassportSessionHandler(config: SandboxVsLiveKYCRouteHandlerC
       return res.status(200).json({
         _id: session._id,
         status: session.status,
-        numAttempts: session.numAttempts ?? 0,
         failureReason: session.failureReason,
         chainId: session.chainId,
       });

--- a/src/services/zk-passport/sessions.ts
+++ b/src/services/zk-passport/sessions.ts
@@ -1,0 +1,316 @@
+import type { Request, Response } from "express";
+import { ObjectId } from "mongodb";
+import {
+  reserveRedemption,
+  completeRedemption,
+  cancelRedemption,
+  forceRefundPayment,
+  PaymentError,
+} from "../payments/functions.js";
+import {
+  PAYMENT_SERVICE_ZK_PASSPORT_VERIFICATION,
+  sessionStatusEnum,
+} from "../../constants/misc.js";
+import { rateLimitByTier } from "../../utils/rate-limiting.js";
+import { getRateLimitTier } from "../../utils/whitelist.js";
+import { pinoOptions, logger } from "../../utils/logger.js";
+import { makeUnknownErrorLoggable } from "../../utils/errors.js";
+import { getRouteHandlerConfig } from "../../init.js";
+import type { SandboxVsLiveKYCRouteHandlerConfig } from "../../types.js";
+
+const zkPassportSessionsLogger = logger.child({
+  base: {
+    ...pinoOptions.base,
+    feature: "holonym",
+    subFeature: "zk-passport-sessions",
+  },
+});
+
+const MAX_ZK_PASSPORT_SESSIONS_PER_USER = 10;
+
+/**
+ * POST /zk-passport/sessions/v2
+ *
+ * Creates a zkPassport verification session bound to a paid commitment.
+ * The session only exists post-payment: `reserveRedemption` validates the
+ * onchain payment + acquires the redemption-pending lock, then we insert
+ * the session and `completeRedemption`. The session status machine (rather
+ * than a reservationToken with 5-minute TTL) becomes the one-verify-per-
+ * payment gate downstream. This mirrors the POST /sessions/v3 pattern used
+ * by Onfido gov-ID sessions.
+ *
+ * Body: { holoUserId, paymentSecret, paymentChainId }
+ * Returns: { session } with _id as the sid.
+ */
+function createPostZkPassportSessionV2Handler(config: SandboxVsLiveKYCRouteHandlerConfig) {
+  return async (req: Request, res: Response) => {
+    let reservationToken: string | null = null;
+
+    try {
+      const holoUserId = req.body?.holoUserId;
+      const address = req.body?.address || null;
+      const paymentSecret = req.body?.paymentSecret;
+      const paymentChainId = req.body?.paymentChainId;
+
+      if (!holoUserId || typeof holoUserId !== "string") {
+        return res.status(400).json({ error: "holoUserId is required" });
+      }
+      if (!paymentSecret || typeof paymentSecret !== "string") {
+        return res.status(400).json({ error: "paymentSecret is required" });
+      }
+      const chainIdNum =
+        typeof paymentChainId === "number" ? paymentChainId : Number(paymentChainId);
+      if (!paymentChainId || isNaN(chainIdNum)) {
+        return res
+          .status(400)
+          .json({ error: "paymentChainId is required and must be a number" });
+      }
+
+      // Rate limit: per-IP, with whitelist tiering, same pattern as Onfido v3
+      const ip = (req.headers["x-forwarded-for"] ?? req.socket.remoteAddress) as string;
+      const tier = await getRateLimitTier(address);
+      const { limitExceeded, maxForTier } = await rateLimitByTier(
+        tier,
+        ip,
+        "zk-passport-sessions",
+      );
+      if (limitExceeded) {
+        zkPassportSessionsLogger.warn(
+          { ip, tier },
+          "Rate limit exceeded for zk-passport-sessions",
+        );
+        return res.status(429).json({
+          error: `This device has reached the maximum number of allowed zkPassport sessions (${maxForTier}). Please try again in 30 days.`,
+        });
+      }
+
+      // Per-user session cap
+      const existingSessions = await config.ZkPassportSessionModel.find({
+        sigDigest: holoUserId,
+        status: {
+          $in: [
+            sessionStatusEnum.IN_PROGRESS,
+            sessionStatusEnum.VERIFICATION_FAILED,
+            sessionStatusEnum.ISSUED,
+          ],
+        },
+      }).exec();
+      if (existingSessions.length >= MAX_ZK_PASSPORT_SESSIONS_PER_USER) {
+        return res.status(400).json({
+          error: `User has reached the maximum number of sessions (${MAX_ZK_PASSPORT_SESSIONS_PER_USER})`,
+        });
+      }
+
+      // Reserve the payment (onchain validation + redemption-pending NX lock)
+      const reservation = await reserveRedemption({
+        secret: paymentSecret,
+        chainId: chainIdNum,
+        service: PAYMENT_SERVICE_ZK_PASSPORT_VERIFICATION,
+        config,
+      });
+      reservationToken = reservation.reservationToken;
+
+      const session = new config.ZkPassportSessionModel({
+        sigDigest: holoUserId,
+        status: sessionStatusEnum.IN_PROGRESS,
+        paymentCommitment: reservation.commitment,
+        chainId: chainIdNum,
+        numAttempts: 0,
+      });
+      await session.save();
+
+      // Complete redemption after the session doc exists so the commitment
+      // cannot be re-used for another session.
+      await completeRedemption({
+        reservationToken: reservationToken!,
+        service: PAYMENT_SERVICE_ZK_PASSPORT_VERIFICATION,
+        fulfillmentReceipt: `zk-passport-session:${session._id}`,
+        config,
+      });
+      reservationToken = null;
+
+      zkPassportSessionsLogger.info(
+        { sid: session._id, chainId: chainIdNum, environment: config.environment },
+        "Created zkPassport session",
+      );
+
+      return res.status(201).json({ session });
+    } catch (err: any) {
+      if (reservationToken) {
+        try {
+          await cancelRedemption({ reservationToken, config });
+        } catch (cancelErr: any) {
+          zkPassportSessionsLogger.error(
+            { error: cancelErr?.message, reservationToken },
+            "Failed to cancel payment reservation after session create failure",
+          );
+        }
+      }
+      if (err instanceof PaymentError) {
+        return res.status(err.statusCode).json({ error: err.message });
+      }
+
+      // Duplicate commitment → session already exists for this payment
+      if (err?.code === 11000) {
+        return res.status(409).json({
+          error: "A session already exists for this payment commitment",
+        });
+      }
+
+      zkPassportSessionsLogger.error(
+        { error: makeUnknownErrorLoggable(err) },
+        "POST /zk-passport/sessions/v2 error",
+      );
+      return res.status(500).json({ error: "An unknown error occurred" });
+    }
+  };
+}
+
+export async function postZkPassportSessionV2Prod(req: Request, res: Response) {
+  return createPostZkPassportSessionV2Handler(getRouteHandlerConfig("live"))(req, res);
+}
+
+export async function postZkPassportSessionV2Sandbox(req: Request, res: Response) {
+  return createPostZkPassportSessionV2Handler(getRouteHandlerConfig("sandbox"))(req, res);
+}
+
+/**
+ * GET /zk-passport/sessions/:sid
+ *
+ * Returns session status. Used by the frontend to gate access to verify/
+ * store/success pages and to render refund affordances.
+ *
+ * Authorization: if the `holoUserId` query param is provided it must match
+ * session.sigDigest. The :sid ObjectId is generated server-side and should
+ * only be known by the session owner, so we accept unauthenticated reads
+ * (mirrors existing session-status patterns in this codebase).
+ */
+function createGetZkPassportSessionHandler(config: SandboxVsLiveKYCRouteHandlerConfig) {
+  return async (req: Request, res: Response) => {
+    try {
+      const sid = req.params.sid;
+      if (!sid) return res.status(400).json({ error: "sid is required" });
+
+      let objectId: ObjectId;
+      try {
+        objectId = new ObjectId(sid);
+      } catch {
+        return res.status(400).json({ error: "Invalid session id" });
+      }
+
+      const session = await config.ZkPassportSessionModel.findOne({ _id: objectId }).exec();
+      if (!session) return res.status(404).json({ error: "Session not found" });
+
+      const holoUserId = req.query?.holoUserId;
+      if (
+        typeof holoUserId === "string" &&
+        holoUserId &&
+        session.sigDigest !== holoUserId
+      ) {
+        return res.status(401).json({ error: "Unauthorized" });
+      }
+
+      return res.status(200).json({
+        _id: session._id,
+        status: session.status,
+        numAttempts: session.numAttempts ?? 0,
+        failureReason: session.failureReason,
+        chainId: session.chainId,
+      });
+    } catch (err: any) {
+      zkPassportSessionsLogger.error(
+        { error: makeUnknownErrorLoggable(err) },
+        "GET /zk-passport/sessions/:sid error",
+      );
+      return res.status(500).json({ error: "An unknown error occurred" });
+    }
+  };
+}
+
+export async function getZkPassportSessionProd(req: Request, res: Response) {
+  return createGetZkPassportSessionHandler(getRouteHandlerConfig("live"))(req, res);
+}
+
+export async function getZkPassportSessionSandbox(req: Request, res: Response) {
+  return createGetZkPassportSessionHandler(getRouteHandlerConfig("sandbox"))(req, res);
+}
+
+const refundLogger = logger.child({
+  msgPrefix: "[POST /zk-passport/sessions/:sid/refund] ",
+  base: { ...pinoOptions.base, feature: "holonym", subFeature: "zk-passport-refund" },
+});
+
+/**
+ * POST /zk-passport/sessions/:sid/refund
+ *
+ * User-initiated refund. Only allowed when session.status === VERIFICATION_FAILED.
+ * The :sid is known only to the session owner; we additionally require
+ * holoUserId in the body to match session.sigDigest.
+ */
+function createRefundZkPassportSessionHandler(config: SandboxVsLiveKYCRouteHandlerConfig) {
+  return async (req: Request, res: Response) => {
+    try {
+      const sid = req.params.sid;
+      const holoUserId = req.body?.holoUserId;
+      if (!sid) return res.status(400).json({ error: "sid is required" });
+      if (!holoUserId || typeof holoUserId !== "string") {
+        return res.status(401).json({ error: "Unauthorized" });
+      }
+
+      let objectId: ObjectId;
+      try {
+        objectId = new ObjectId(sid);
+      } catch {
+        return res.status(400).json({ error: "Invalid session id" });
+      }
+
+      const session = await config.ZkPassportSessionModel.findOne({ _id: objectId }).exec();
+      if (!session) return res.status(404).json({ error: "Session not found" });
+      if (session.sigDigest !== holoUserId) {
+        return res.status(401).json({ error: "Unauthorized" });
+      }
+
+      if (session.status === sessionStatusEnum.REFUNDED) {
+        return res.status(200).json({
+          alreadyRefunded: true,
+          txHashes: session.refundTxHashes ?? [],
+        });
+      }
+      if (session.status !== sessionStatusEnum.VERIFICATION_FAILED) {
+        return res.status(400).json({ error: "Session is not eligible for refund" });
+      }
+      if (!session.paymentCommitment || !session.chainId) {
+        return res.status(400).json({ error: "Session missing payment metadata" });
+      }
+
+      const result = await forceRefundPayment(
+        session.paymentCommitment,
+        session.chainId,
+        { logger: refundLogger, environment: config.environment },
+      );
+      if (!result.success) {
+        return res.status(result.status).json({ error: result.error });
+      }
+
+      session.status = sessionStatusEnum.REFUNDED;
+      session.refundTxHashes = [...(session.refundTxHashes ?? []), result.txHash];
+      await session.save();
+
+      return res.status(200).json({ txHash: result.txHash });
+    } catch (err: any) {
+      refundLogger.error(
+        { error: makeUnknownErrorLoggable(err) },
+        "Error processing zkPassport session refund",
+      );
+      return res.status(500).json({ error: "An unknown error occurred" });
+    }
+  };
+}
+
+export async function refundZkPassportSessionProd(req: Request, res: Response) {
+  return createRefundZkPassportSessionHandler(getRouteHandlerConfig("live"))(req, res);
+}
+
+export async function refundZkPassportSessionSandbox(req: Request, res: Response) {
+  return createRefundZkPassportSessionHandler(getRouteHandlerConfig("sandbox"))(req, res);
+}

--- a/src/services/zk-passport/verify-and-issue.ts
+++ b/src/services/zk-passport/verify-and-issue.ts
@@ -536,7 +536,7 @@ function createVerifyAndIssue(config: SandboxVsLiveKYCRouteHandlerConfig) {
       return res.status(200).json(response);
     } catch (err: any) {
       if (err.status && err.error) {
-        return res.status(err.status).json({ err: err.error });
+        return res.status(err.status).json({ error: err.error });
       }
 
       endpointLogger.error(

--- a/src/services/zk-passport/verify-and-issue.ts
+++ b/src/services/zk-passport/verify-and-issue.ts
@@ -202,33 +202,6 @@ function formatDateOfBirth(dob: Date | string): string {
   return `${year}-${month}-${day}`;
 }
 
-const MAX_VERIFY_ATTEMPTS = 3;
-
-/**
- * Increment numAttempts on the session; flip to VERIFICATION_FAILED when the
- * cap is reached. Errors are logged but not rethrown — a failed session write
- * should not mask the verification error.
- */
-async function recordVerificationFailure(
-  session: any,
-  failureReason: string,
-) {
-  if (!session) return;
-  try {
-    session.numAttempts = (session.numAttempts ?? 0) + 1;
-    session.failureReason = failureReason;
-    if (session.numAttempts >= MAX_VERIFY_ATTEMPTS) {
-      session.status = sessionStatusEnum.VERIFICATION_FAILED;
-    }
-    await session.save();
-  } catch (err) {
-    endpointLogger.error(
-      { error: makeUnknownErrorLoggable(err) },
-      "Failed to record verification failure on session",
-    );
-  }
-}
-
 /**
  * Map ZKPassport SDK error shapes to our structured error codes so the
  * frontend can render PRD §4.2 UX (unsupported doc, PFM failure, generic).
@@ -265,7 +238,13 @@ function createVerifyAndIssue(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
     let session: any = null;
     try {
-      const { sid, proofs, queryResult, nullifier: issuanceNullifier } = req.body;
+      const {
+        sid,
+        holoUserId,
+        proofs,
+        queryResult,
+        nullifier: issuanceNullifier,
+      } = req.body;
 
       // --- Validate request body ---
 
@@ -273,6 +252,13 @@ function createVerifyAndIssue(config: SandboxVsLiveKYCRouteHandlerConfig) {
         return res.status(400).json({
           code: "MISSING_SESSION_ID",
           error: "sid is required",
+        });
+      }
+
+      if (!holoUserId || typeof holoUserId !== "string") {
+        return res.status(401).json({
+          code: "UNAUTHORIZED",
+          error: "holoUserId is required",
         });
       }
 
@@ -308,11 +294,22 @@ function createVerifyAndIssue(config: SandboxVsLiveKYCRouteHandlerConfig) {
         });
       }
 
-      // ISSUED is allowed here: the existing 5-day nullifier+uniqueIdentifier
-      // recovery branch below is what makes re-calls idempotent. Outside that
-      // window, the nullifierAndCreds lookup returns null and the normal-flow
-      // branch will reject on the 11-month dedup check or missing session,
-      // effectively closing the window.
+      // Bind caller to session owner. Without this, any party who learns a
+      // victim's IN_PROGRESS sid could flip it to ISSUED using their own
+      // proof — burning the victim's $3 and receiving creds bound to the
+      // attacker's own issuanceNullifier.
+      if (session.sigDigest !== holoUserId) {
+        return res.status(401).json({
+          code: "UNAUTHORIZED",
+          error: "Session does not belong to this user",
+        });
+      }
+
+      // Allow both IN_PROGRESS and ISSUED at this point so the 5-day
+      // nullifier+uniqueIdentifier recovery branch below can idempotently
+      // re-fetch creds. Post-recovery-branch, we re-tighten to IN_PROGRESS
+      // only so a different nullifier/passport cannot mint a second
+      // credential on an already-issued paid session.
       if (
         session.status !== sessionStatusEnum.IN_PROGRESS &&
         session.status !== sessionStatusEnum.ISSUED
@@ -368,7 +365,6 @@ function createVerifyAndIssue(config: SandboxVsLiveKYCRouteHandlerConfig) {
           { error: makeUnknownErrorLoggable(err) },
           "ZK Passport verification threw an error"
         );
-        await recordVerificationFailure(session, "ZK_PASSPORT_VERIFY_THREW");
         return res.status(400).json({
           code: classifyZkPassportError(err),
           error: "ZK Passport proof verification failed.",
@@ -381,7 +377,6 @@ function createVerifyAndIssue(config: SandboxVsLiveKYCRouteHandlerConfig) {
           "ZK Passport proof verification returned verified=false"
         );
         const code = classifyZkPassportError(verificationResult.queryResultErrors);
-        await recordVerificationFailure(session, code);
         return res.status(400).json({
           code,
           error: "ZK Passport proof verification failed.",
@@ -424,7 +419,6 @@ function createVerifyAndIssue(config: SandboxVsLiveKYCRouteHandlerConfig) {
           "ZK Passport nationality not found in countryCodeToPrime"
         );
 
-        await recordVerificationFailure(session, "ZK_PASSPORT_UNSUPPORTED_DOCUMENT");
         return res.status(400).json({
           code: "ZK_PASSPORT_UNSUPPORTED_DOCUMENT",
           error: `Unsupported country (${nationalityStr}) from ZK Passport proof`,
@@ -478,6 +472,16 @@ function createVerifyAndIssue(config: SandboxVsLiveKYCRouteHandlerConfig) {
       }
 
       // --- Normal first-time flow ---
+
+      // No nullifier match means this is a fresh issuance, not a recovery
+      // re-fetch. An already-ISSUED session reaching this point would mint
+      // a second credential on one paid session — reject.
+      if (session.status !== sessionStatusEnum.IN_PROGRESS) {
+        return res.status(400).json({
+          code: "SESSION_NOT_ELIGIBLE",
+          error: `Session is not eligible for fresh issuance (status: ${session.status})`,
+        });
+      }
 
       if (config.environment === "live") {
         const existingUser = await findOneUserVerificationLast11Months(uuidV1, uuidV2);

--- a/src/services/zk-passport/verify-and-issue.ts
+++ b/src/services/zk-passport/verify-and-issue.ts
@@ -1,4 +1,5 @@
 import { Request, Response } from "express";
+import { ObjectId } from "mongodb";
 import ethersPkg from "ethers";
 const { ethers } = ethersPkg;
 import { poseidon } from "circomlibjs-old";
@@ -7,6 +8,7 @@ import {
   UserVerifications,
   VerificationCollisionMetadata,
 } from "../../init.js";
+import { sessionStatusEnum } from "../../constants/misc.js";
 import {
   getDateAsInt,
   govIdUUID,
@@ -200,6 +202,52 @@ function formatDateOfBirth(dob: Date | string): string {
   return `${year}-${month}-${day}`;
 }
 
+const MAX_VERIFY_ATTEMPTS = 3;
+
+/**
+ * Increment numAttempts on the session; flip to VERIFICATION_FAILED when the
+ * cap is reached. Errors are logged but not rethrown — a failed session write
+ * should not mask the verification error.
+ */
+async function recordVerificationFailure(
+  session: any,
+  failureReason: string,
+) {
+  if (!session) return;
+  try {
+    session.numAttempts = (session.numAttempts ?? 0) + 1;
+    session.failureReason = failureReason;
+    if (session.numAttempts >= MAX_VERIFY_ATTEMPTS) {
+      session.status = sessionStatusEnum.VERIFICATION_FAILED;
+    }
+    await session.save();
+  } catch (err) {
+    endpointLogger.error(
+      { error: makeUnknownErrorLoggable(err) },
+      "Failed to record verification failure on session",
+    );
+  }
+}
+
+/**
+ * Map ZKPassport SDK error shapes to our structured error codes so the
+ * frontend can render PRD §4.2 UX (unsupported doc, PFM failure, generic).
+ */
+function classifyZkPassportError(err: unknown): string {
+  const msg =
+    typeof err === "string"
+      ? err
+      : (err as any)?.message || JSON.stringify(err ?? "");
+  const lower = (msg || "").toLowerCase();
+  if (lower.includes("face match") || lower.includes("pfm") || lower.includes("private face match")) {
+    return "ZK_PASSPORT_PFM_FAILED";
+  }
+  if (lower.includes("unsupported") || lower.includes("not supported") || lower.includes("document")) {
+    return "ZK_PASSPORT_UNSUPPORTED_DOCUMENT";
+  }
+  return "ZK_PASSPORT_VERIFICATION_FAILED";
+}
+
 /**
  * POST /zk-passport/verify-and-issue
  *
@@ -215,10 +263,18 @@ function formatDateOfBirth(dob: Date | string): string {
  */
 function createVerifyAndIssue(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
+    let session: any = null;
     try {
-      const { proofs, queryResult, nullifier: issuanceNullifier } = req.body;
+      const { sid, proofs, queryResult, nullifier: issuanceNullifier } = req.body;
 
       // --- Validate request body ---
+
+      if (!sid || typeof sid !== "string") {
+        return res.status(400).json({
+          code: "MISSING_SESSION_ID",
+          error: "sid is required",
+        });
+      }
 
       if (!proofs || !Array.isArray(proofs) || proofs.length === 0) {
         return res.status(400).json({ error: "Missing or invalid proofs array" });
@@ -230,6 +286,41 @@ function createVerifyAndIssue(config: SandboxVsLiveKYCRouteHandlerConfig) {
 
       if (!issuanceNullifier) {
         return res.status(400).json({ error: "Missing nullifier (issuance nullifier)" });
+      }
+
+      // --- Load + gate the session ---
+
+      let sessionObjectId: ObjectId;
+      try {
+        sessionObjectId = new ObjectId(sid);
+      } catch {
+        return res.status(400).json({
+          code: "INVALID_SESSION_ID",
+          error: "Invalid sid",
+        });
+      }
+
+      session = await config.ZkPassportSessionModel.findOne({ _id: sessionObjectId }).exec();
+      if (!session) {
+        return res.status(404).json({
+          code: "SESSION_NOT_FOUND",
+          error: "Session not found",
+        });
+      }
+
+      // ISSUED is allowed here: the existing 5-day nullifier+uniqueIdentifier
+      // recovery branch below is what makes re-calls idempotent. Outside that
+      // window, the nullifierAndCreds lookup returns null and the normal-flow
+      // branch will reject on the 11-month dedup check or missing session,
+      // effectively closing the window.
+      if (
+        session.status !== sessionStatusEnum.IN_PROGRESS &&
+        session.status !== sessionStatusEnum.ISSUED
+      ) {
+        return res.status(400).json({
+          code: "SESSION_NOT_ELIGIBLE",
+          error: `Session is not eligible for verification (status: ${session.status})`,
+        });
       }
 
       try {
@@ -277,7 +368,9 @@ function createVerifyAndIssue(config: SandboxVsLiveKYCRouteHandlerConfig) {
           { error: makeUnknownErrorLoggable(err) },
           "ZK Passport verification threw an error"
         );
+        await recordVerificationFailure(session, "ZK_PASSPORT_VERIFY_THREW");
         return res.status(400).json({
+          code: classifyZkPassportError(err),
           error: "ZK Passport proof verification failed.",
         });
       }
@@ -287,7 +380,10 @@ function createVerifyAndIssue(config: SandboxVsLiveKYCRouteHandlerConfig) {
           { queryResultErrors: verificationResult.queryResultErrors },
           "ZK Passport proof verification returned verified=false"
         );
+        const code = classifyZkPassportError(verificationResult.queryResultErrors);
+        await recordVerificationFailure(session, code);
         return res.status(400).json({
+          code,
           error: "ZK Passport proof verification failed.",
           details: verificationResult.queryResultErrors,
         });
@@ -328,7 +424,9 @@ function createVerifyAndIssue(config: SandboxVsLiveKYCRouteHandlerConfig) {
           "ZK Passport nationality not found in countryCodeToPrime"
         );
 
+        await recordVerificationFailure(session, "ZK_PASSPORT_UNSUPPORTED_DOCUMENT");
         return res.status(400).json({
+          code: "ZK_PASSPORT_UNSUPPORTED_DOCUMENT",
           error: `Unsupported country (${nationalityStr}) from ZK Passport proof`,
         });
       }
@@ -366,9 +464,15 @@ function createVerifyAndIssue(config: SandboxVsLiveKYCRouteHandlerConfig) {
         response.metadata = creds;
 
         endpointLogger.info(
-          { uuidV2, uniqueIdentifier: verificationResult.uniqueIdentifier },
+          { uuidV2, uniqueIdentifier: verificationResult.uniqueIdentifier, sid: session._id },
           "Re-issuing ZK Passport credentials (recovery branch)"
         );
+
+        // Idempotent re-issuance within 5 days. Keep session status ISSUED.
+        if (session && session.status !== sessionStatusEnum.ISSUED) {
+          session.status = sessionStatusEnum.ISSUED;
+          try { await session.save(); } catch { /* non-fatal */ }
+        }
 
         return res.status(200).json(response);
       }
@@ -414,9 +518,20 @@ function createVerifyAndIssue(config: SandboxVsLiveKYCRouteHandlerConfig) {
       await newNullifierAndCreds.save();
 
       endpointLogger.info(
-        { uuidV2, uniqueIdentifier: verificationResult.uniqueIdentifier },
+        { uuidV2, uniqueIdentifier: verificationResult.uniqueIdentifier, sid: session._id },
         "Issuing ZK Passport credentials"
       );
+
+      // Flip session to ISSUED. This is the one-verify-per-payment gate for
+      // future verify-and-issue calls (the 5-day nullifier recovery window
+      // allows idempotent re-fetches via the branch above).
+      session.status = sessionStatusEnum.ISSUED;
+      try { await session.save(); } catch (err) {
+        endpointLogger.error(
+          { error: makeUnknownErrorLoggable(err), sid: session._id },
+          "Failed to flip zkPassport session to ISSUED — creds were issued but session state is stale",
+        );
+      }
 
       return res.status(200).json(response);
     } catch (err: any) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -269,7 +269,6 @@ export type IZkPassportSession = {
   status?: string;
   paymentCommitment?: string;
   chainId?: number;
-  numAttempts?: number;
   failureReason?: string;
   refundTxHashes?: string[];
   createdAt?: Date;

--- a/src/types.ts
+++ b/src/types.ts
@@ -263,6 +263,20 @@ export type IBiometricsSession = {
   paymentCommitment?: string;
 };
 
+export type IZkPassportSession = {
+  _id?: Types.ObjectId;
+  sigDigest?: string;
+  status?: string;
+  paymentCommitment?: string;
+  chainId?: number;
+  numAttempts?: number;
+  failureReason?: string;
+  refundTxHashes?: string[];
+  createdAt?: Date;
+};
+
+export type ISandboxZkPassportSession = IZkPassportSession;
+
 export type ISessionRefundMutex = {
   _id?: Types.ObjectId;
   sessionId?: string;
@@ -699,6 +713,7 @@ export type SandboxVsLiveKYCRouteHandlerConfig = {
   AMLChecksSessionModel: Model<IAmlChecksSession | ISandboxAmlChecksSession>
   CleanHandsNullifierAndCredsModel: Model<ICleanHandsNullifierAndCreds | ISandboxCleanHandsNullifierAndCreds>
   ZkPassportNullifierAndCredsModel: Model<IZkPassportNullifierAndCreds | ISandboxZkPassportNullifierAndCreds>
+  ZkPassportSessionModel: Model<IZkPassportSession | ISandboxZkPassportSession>
   SanctionsResultModel: Model<ISanctionsResult>
   PaymentRedemptionModel: Model<IPaymentRedemption | ISandboxPaymentRedemption>
   PaymentSecretModel: Model<IPaymentSecret | ISandboxPaymentSecret>


### PR DESCRIPTION
Adds PAYMENT_SERVICE_ZK_PASSPORT_VERIFICATION + zkPassportSessionUSDPrice (3.0) and wires the price through GET /payments/payment-params.

New ZkPassportSession model (plus sandbox twin) binds a paid commitment to a verification attempt. Status lifecycle: IN_PROGRESS -> ISSUED | VERIFICATION_FAILED | REFUNDED. Session only exists post-payment.

New endpoints:
- POST /zk-passport/sessions/v2: reserveRedemption + session insert + completeRedemption. Mirrors POST /sessions/v3 (Onfido). Redemption is consumed at session creation; the session status machine is the one-verify-per-payment gate downstream. Plan phrased this as "completeRedemption at verify-and-issue" but the Onfido pattern is a closer match and avoids reservationToken TTL issues.
- GET /zk-passport/sessions/:sid: session status for frontend gating.
- POST /zk-passport/sessions/:sid/refund: user-initiated force refund, only when status=VERIFICATION_FAILED.

POST /zk-passport/verify-and-issue now requires sid; loads+gates session, increments numAttempts on failure (cap 3 flips to VERIFICATION_FAILED), flips to ISSUED on success. The existing 5-day nullifierAndCreds recovery branch remains the idempotent re-issuance path.

Structured error codes added: ZK_PASSPORT_UNSUPPORTED_DOCUMENT, ZK_PASSPORT_PFM_FAILED, ZK_PASSPORT_VERIFICATION_FAILED, SESSION_NOT_FOUND, SESSION_NOT_ELIGIBLE, etc.