### PR TITLE
fix(refunds): reject sybil and stale-window sessions

### DIFF
--- a/src/constants/misc.ts
+++ b/src/constants/misc.ts
@@ -209,6 +209,13 @@ export const humanIDPaymentsABI = [
 export const PAYMENT_SERVICE_SBT_MINT = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('mint_zeronym_v3_sbt'))
 
 /**
+ * Refund eligibility window. Sessions whose on-chain payment timestamp is older
+ * than this are no longer refundable. Expressed in seconds to match the units
+ * of `payments(commitment).timestamp` on the HumanIDPayments contract.
+ */
+export const REFUND_WINDOW_SECONDS = 7 * 24 * 60 * 60
+
+/**
  * Per-flow service identifiers for verification payments.
  * Used to distinguish payment attribution per verification type.
  */

--- a/src/services/aml-sessions/endpoints.ts
+++ b/src/services/aml-sessions/endpoints.ts
@@ -3056,11 +3056,27 @@ function createRefundCleanHandsSessionRouteHandler(
           error: "Refunds are not supported on this chain",
         });
       }
-      const onChainPayment = await getPaymentFromContract(
-        session.paymentCommitment,
-        session.chainId,
-        contractAddress
-      );
+      let onChainPayment;
+      try {
+        onChainPayment = await getPaymentFromContract(
+          session.paymentCommitment,
+          session.chainId,
+          contractAddress
+        );
+      } catch (rpcErr) {
+        refundCleanHandsLogger.error(
+          {
+            event: "refund_rpc_failed",
+            sid: session._id?.toString(),
+            chainId: session.chainId,
+            error: makeUnknownErrorLoggable(rpcErr),
+          },
+          "Refund window check failed: on-chain payment read errored"
+        );
+        return res.status(503).json({
+          error: "Unable to verify payment on-chain. Please try again.",
+        });
+      }
       if (!onChainPayment) {
         refundCleanHandsLogger.info(
           { sid: session._id?.toString(), commitment: session.paymentCommitment, chainId: session.chainId },

--- a/src/services/aml-sessions/endpoints.ts
+++ b/src/services/aml-sessions/endpoints.ts
@@ -46,7 +46,7 @@ import {
 } from "../../utils/clean-hands-nullifier-and-creds.js";
 import { parseStatementForUserCertification } from '../../utils/clean-hands-misc.js'
 import { findUserVerification } from "../../utils/user-verifications.js";
-import { makeUnknownErrorLoggable, toAlreadyRegisteredStr } from "../../utils/errors.js";
+import { makeUnknownErrorLoggable, toAlreadyRegisteredStr, isAlreadyRegisteredFailure } from "../../utils/errors.js";
 import {
   supportedChainIds,
   amlSessionUSDPrice,
@@ -55,12 +55,15 @@ import {
   cleanHandsSessionStatusEnum,
   PAYMENT_SERVICE_CLEAN_HANDS_VERIFICATION,
   PAYMENT_SERVICE_CLEAN_HANDS_ZK_PASSPORT_VERIFICATION,
+  REFUND_WINDOW_SECONDS,
+  humanIDPaymentsContractAddresses,
 } from "../../constants/misc.js";
 import {
   reserveRedemption,
   completeRedemption,
   forceRefundPayment,
   cancelRedemption,
+  getPaymentFromContract,
   PaymentError,
 } from "../payments/functions.js";
 import V3NameDOBVKey from "../../constants/zk/V3NameDOB.verification_key.json" with { type: "json" };
@@ -3035,6 +3038,42 @@ function createRefundCleanHandsSessionRouteHandler(
         return res.status(400).json({
           error: "Session predates refund-capable payment model",
         });
+      }
+
+      if (isAlreadyRegisteredFailure(session.verificationFailureReason)) {
+        refundCleanHandsLogger.info(
+          { sid: session._id?.toString() },
+          "Refund rejected: already-registered failure"
+        );
+        return res.status(400).json({
+          error: "Refund not available for already-registered failures",
+        });
+      }
+
+      const contractAddress = humanIDPaymentsContractAddresses[session.chainId];
+      if (!contractAddress) {
+        return res.status(400).json({
+          error: "Refunds are not supported on this chain",
+        });
+      }
+      const onChainPayment = await getPaymentFromContract(
+        session.paymentCommitment,
+        session.chainId,
+        contractAddress
+      );
+      if (!onChainPayment) {
+        refundCleanHandsLogger.info(
+          { sid: session._id?.toString(), commitment: session.paymentCommitment, chainId: session.chainId },
+          "Refund rejected: payment not found on-chain"
+        );
+        return res.status(400).json({ error: "Payment not found on-chain" });
+      }
+      if (Math.floor(Date.now() / 1000) - onChainPayment.timestamp > REFUND_WINDOW_SECONDS) {
+        refundCleanHandsLogger.info(
+          { sid: session._id?.toString(), paymentTimestamp: onChainPayment.timestamp },
+          "Refund rejected: refund window expired"
+        );
+        return res.status(400).json({ error: "Refund window has expired" });
       }
 
       const result = await forceRefundPayment(

--- a/src/services/biometrics-sessions/endpoints.js
+++ b/src/services/biometrics-sessions/endpoints.js
@@ -392,11 +392,27 @@ async function refundBiometricsSession(req, res) {
         error: "Refunds are not supported on this chain",
       });
     }
-    const onChainPayment = await getPaymentFromContract(
-      session.paymentCommitment,
-      session.chainId,
-      contractAddress
-    );
+    let onChainPayment;
+    try {
+      onChainPayment = await getPaymentFromContract(
+        session.paymentCommitment,
+        session.chainId,
+        contractAddress
+      );
+    } catch (rpcErr) {
+      refundBiometricsLogger.error(
+        {
+          event: "refund_rpc_failed",
+          sid: session._id?.toString(),
+          chainId: session.chainId,
+          error: rpcErr?.message || String(rpcErr),
+        },
+        "Refund window check failed: on-chain payment read errored"
+      );
+      return res.status(503).json({
+        error: "Unable to verify payment on-chain. Please try again.",
+      });
+    }
     if (!onChainPayment) {
       refundBiometricsLogger.info(
         { sid: session._id?.toString(), commitment: session.paymentCommitment, chainId: session.chainId },

--- a/src/services/biometrics-sessions/endpoints.js
+++ b/src/services/biometrics-sessions/endpoints.js
@@ -4,16 +4,20 @@ import { BiometricsSession, getRouteHandlerConfig } from "../../init.js";
 import {
   sessionStatusEnum,
   PAYMENT_SERVICE_BIOMETRICS_VERIFICATION,
+  REFUND_WINDOW_SECONDS,
+  humanIDPaymentsContractAddresses,
 } from "../../constants/misc.js";
 import { pinoOptions, logger } from "../../utils/logger.js";
 import { v4 as uuidV4 } from "uuid";
 import { rateLimitByTier } from "../../utils/rate-limiting.js";
 import { getRateLimitTier } from "../../utils/whitelist.js";
+import { isAlreadyRegisteredFailure } from "../../utils/errors.js";
 import {
   reserveRedemption,
   completeRedemption,
   cancelRedemption,
   forceRefundPayment,
+  getPaymentFromContract,
   PaymentError,
 } from "../payments/functions.js";
 
@@ -370,6 +374,42 @@ async function refundBiometricsSession(req, res) {
       return res.status(400).json({
         error: "Session predates refund-capable payment model",
       });
+    }
+
+    if (isAlreadyRegisteredFailure(session.verificationFailureReason)) {
+      refundBiometricsLogger.info(
+        { sid: session._id?.toString() },
+        "Refund rejected: already-registered failure"
+      );
+      return res.status(400).json({
+        error: "Refund not available for already-registered failures",
+      });
+    }
+
+    const contractAddress = humanIDPaymentsContractAddresses[session.chainId];
+    if (!contractAddress) {
+      return res.status(400).json({
+        error: "Refunds are not supported on this chain",
+      });
+    }
+    const onChainPayment = await getPaymentFromContract(
+      session.paymentCommitment,
+      session.chainId,
+      contractAddress
+    );
+    if (!onChainPayment) {
+      refundBiometricsLogger.info(
+        { sid: session._id?.toString(), commitment: session.paymentCommitment, chainId: session.chainId },
+        "Refund rejected: payment not found on-chain"
+      );
+      return res.status(400).json({ error: "Payment not found on-chain" });
+    }
+    if (Math.floor(Date.now() / 1000) - onChainPayment.timestamp > REFUND_WINDOW_SECONDS) {
+      refundBiometricsLogger.info(
+        { sid: session._id?.toString(), paymentTimestamp: onChainPayment.timestamp },
+        "Refund rejected: refund window expired"
+      );
+      return res.status(400).json({ error: "Refund window has expired" });
     }
 
     const result = await forceRefundPayment(

--- a/src/services/phone/sessions/endpoints.ts
+++ b/src/services/phone/sessions/endpoints.ts
@@ -31,6 +31,8 @@ import {
   payPalApiUrlBase,
   SessionStatus,
   PAYMENT_SERVICE_PHONE_VERIFICATION,
+  REFUND_WINDOW_SECONDS,
+  humanIDPaymentsContractAddresses,
 } from '../../../constants/misc.js'
 import { getRouteHandlerConfig } from '../../../init.js'
 import {
@@ -38,6 +40,7 @@ import {
   completeRedemption,
   cancelRedemption,
   forceRefundPayment,
+  getPaymentFromContract,
   PaymentError,
 } from '../../payments/functions.js'
 import {
@@ -46,7 +49,7 @@ import {
   getRefundDetails as getPayPalRefundDetails,
   capturePayPalOrder
 } from '../../../utils/paypal.js'
-import { makeUnknownErrorLoggable } from '../../../utils/errors.js'
+import { makeUnknownErrorLoggable, isAlreadyRegisteredFailure } from '../../../utils/errors.js'
 import { pinoOptions, logger } from '../../../utils/logger.js'
 import { usdToETH, usdToFTM, usdToAVAX } from '../../../utils/cmc.js'
 import { getProvider } from '../../../utils/misc.js'
@@ -735,6 +738,43 @@ function createRefundPhoneSessionV3(config: RefundPhoneSessionV3Config) {
         return res.status(400).json({
           error: 'Session predates refund-capable payment model',
         })
+      }
+
+      const failureReason = item.verificationFailureReason?.S
+      if (isAlreadyRegisteredFailure(failureReason)) {
+        refundPhoneSessionLogger.info(
+          { sid: id },
+          'Refund rejected: already-registered failure'
+        )
+        return res.status(400).json({
+          error: 'Refund not available for already-registered failures',
+        })
+      }
+
+      const contractAddress = humanIDPaymentsContractAddresses[chainId]
+      if (!contractAddress) {
+        return res.status(400).json({
+          error: 'Refunds are not supported on this chain',
+        })
+      }
+      const onChainPayment = await getPaymentFromContract(
+        paymentCommitment,
+        chainId,
+        contractAddress
+      )
+      if (!onChainPayment) {
+        refundPhoneSessionLogger.info(
+          { sid: id, commitment: paymentCommitment, chainId },
+          'Refund rejected: payment not found on-chain'
+        )
+        return res.status(400).json({ error: 'Payment not found on-chain' })
+      }
+      if (Math.floor(Date.now() / 1000) - onChainPayment.timestamp > REFUND_WINDOW_SECONDS) {
+        refundPhoneSessionLogger.info(
+          { sid: id, paymentTimestamp: onChainPayment.timestamp },
+          'Refund rejected: refund window expired'
+        )
+        return res.status(400).json({ error: 'Refund window has expired' })
       }
 
       const refundResult = await forceRefundPayment(paymentCommitment, chainId, {

--- a/src/services/phone/sessions/endpoints.ts
+++ b/src/services/phone/sessions/endpoints.ts
@@ -757,11 +757,27 @@ function createRefundPhoneSessionV3(config: RefundPhoneSessionV3Config) {
           error: 'Refunds are not supported on this chain',
         })
       }
-      const onChainPayment = await getPaymentFromContract(
-        paymentCommitment,
-        chainId,
-        contractAddress
-      )
+      let onChainPayment
+      try {
+        onChainPayment = await getPaymentFromContract(
+          paymentCommitment,
+          chainId,
+          contractAddress
+        )
+      } catch (rpcErr) {
+        refundPhoneSessionLogger.error(
+          {
+            event: 'refund_rpc_failed',
+            sid: id,
+            chainId,
+            error: makeUnknownErrorLoggable(rpcErr),
+          },
+          'Refund window check failed: on-chain payment read errored'
+        )
+        return res.status(503).json({
+          error: 'Unable to verify payment on-chain. Please try again.',
+        })
+      }
       if (!onChainPayment) {
         refundPhoneSessionLogger.info(
           { sid: id, commitment: paymentCommitment, chainId },

--- a/src/services/sessions/endpoints.ts
+++ b/src/services/sessions/endpoints.ts
@@ -25,12 +25,15 @@ import {
   payPalApiUrlBase,
   idvSessionUSDPrice,
   PAYMENT_SERVICE_GOV_ID_VERIFICATION,
+  REFUND_WINDOW_SECONDS,
+  humanIDPaymentsContractAddresses,
 } from "../../constants/misc.js";
 import {
   reserveRedemption,
   completeRedemption,
   cancelRedemption,
   forceRefundPayment,
+  getPaymentFromContract,
   PaymentError,
 } from "../payments/functions.js";
 import {
@@ -47,7 +50,7 @@ import { getSessionById } from "../../utils/sessions.js";
 import { objectIdFiveDaysAgo } from "../../utils/utils.js";
 import { getRateLimitTier } from "../../utils/whitelist.js";
 import type { SandboxVsLiveKYCRouteHandlerConfig } from "../../types.js"
-import { makeUnknownErrorLoggable } from "../../utils/errors.js";
+import { makeUnknownErrorLoggable, isAlreadyRegisteredFailure } from "../../utils/errors.js";
 
 const postSessionsV2Logger = logger.child({
   msgPrefix: "[POST /sessions/v2] ",
@@ -1453,6 +1456,42 @@ function createRefundSessionRouteHandler(config: SandboxVsLiveKYCRouteHandlerCon
         return res.status(400).json({
           error: "Session predates refund-capable payment model",
         });
+      }
+
+      if (isAlreadyRegisteredFailure(session.verificationFailureReason)) {
+        refundSessionLogger.info(
+          { sid: session._id?.toString() },
+          "Refund rejected: already-registered failure"
+        );
+        return res.status(400).json({
+          error: "Refund not available for already-registered failures",
+        });
+      }
+
+      const contractAddress = humanIDPaymentsContractAddresses[session.chainId];
+      if (!contractAddress) {
+        return res.status(400).json({
+          error: "Refunds are not supported on this chain",
+        });
+      }
+      const onChainPayment = await getPaymentFromContract(
+        session.paymentCommitment,
+        session.chainId,
+        contractAddress
+      );
+      if (!onChainPayment) {
+        refundSessionLogger.info(
+          { sid: session._id?.toString(), commitment: session.paymentCommitment, chainId: session.chainId },
+          "Refund rejected: payment not found on-chain"
+        );
+        return res.status(400).json({ error: "Payment not found on-chain" });
+      }
+      if (Math.floor(Date.now() / 1000) - onChainPayment.timestamp > REFUND_WINDOW_SECONDS) {
+        refundSessionLogger.info(
+          { sid: session._id?.toString(), paymentTimestamp: onChainPayment.timestamp },
+          "Refund rejected: refund window expired"
+        );
+        return res.status(400).json({ error: "Refund window has expired" });
       }
 
       const result = await forceRefundPayment(

--- a/src/services/sessions/endpoints.ts
+++ b/src/services/sessions/endpoints.ts
@@ -1474,11 +1474,27 @@ function createRefundSessionRouteHandler(config: SandboxVsLiveKYCRouteHandlerCon
           error: "Refunds are not supported on this chain",
         });
       }
-      const onChainPayment = await getPaymentFromContract(
-        session.paymentCommitment,
-        session.chainId,
-        contractAddress
-      );
+      let onChainPayment;
+      try {
+        onChainPayment = await getPaymentFromContract(
+          session.paymentCommitment,
+          session.chainId,
+          contractAddress
+        );
+      } catch (rpcErr) {
+        refundSessionLogger.error(
+          {
+            event: "refund_rpc_failed",
+            sid: session._id?.toString(),
+            chainId: session.chainId,
+            error: makeUnknownErrorLoggable(rpcErr),
+          },
+          "Refund window check failed: on-chain payment read errored"
+        );
+        return res.status(503).json({
+          error: "Unable to verify payment on-chain. Please try again.",
+        });
+      }
       if (!onChainPayment) {
         refundSessionLogger.info(
           { sid: session._id?.toString(), commitment: session.paymentCommitment, chainId: session.chainId },

--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -19,4 +19,28 @@ describe("isAlreadyRegisteredFailure", () => {
     expect(isAlreadyRegisteredFailure(undefined)).toBe(false);
     expect(isAlreadyRegisteredFailure("")).toBe(false);
   });
+
+  it("detects phone sybil prefix from failPhoneSession", () => {
+    // Mirrors services/phone/check-number.ts:463
+    expect(isAlreadyRegisteredFailure("Number has been registered already")).toBe(true);
+    expect(isAlreadyRegisteredFailure("Number has been registered already!")).toBe(true);
+  });
+
+  it("detects biometrics sybil prefix from FaceTec duplicate-match path", () => {
+    // Mirrors services/facetec/{credentials,v2/no-sybils/credentials,enrollment-3d}.js
+    expect(
+      isAlreadyRegisteredFailure(
+        "Face scan failed as highly matching duplicates are found."
+      )
+    ).toBe(true);
+  });
+
+  it("detects cross-provider sybil reason", () => {
+    // services/zk-passport/verify-and-issue.ts:514
+    expect(
+      isAlreadyRegisteredFailure(
+        "User has already registered (cross-provider sybil check)"
+      )
+    ).toBe(true);
+  });
 });

--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "bun:test";
+import { isAlreadyRegisteredFailure, toAlreadyRegisteredStr } from "./errors.js";
+
+describe("isAlreadyRegisteredFailure", () => {
+  it("returns true for the canonical writer's output (round-trip pin)", () => {
+    expect(isAlreadyRegisteredFailure(toAlreadyRegisteredStr("abc"))).toBe(true);
+  });
+
+  it("returns true for the prefix without a userId suffix", () => {
+    expect(isAlreadyRegisteredFailure("User has already registered")).toBe(true);
+  });
+
+  it("returns false for unrelated failure reasons", () => {
+    expect(isAlreadyRegisteredFailure("User failed liveness check")).toBe(false);
+  });
+
+  it("returns false for null, undefined, and empty strings", () => {
+    expect(isAlreadyRegisteredFailure(null)).toBe(false);
+    expect(isAlreadyRegisteredFailure(undefined)).toBe(false);
+    expect(isAlreadyRegisteredFailure("")).toBe(false);
+  });
+});

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -5,12 +5,35 @@ export function toAlreadyRegisteredStr(userId: string) {
 }
 
 /**
+ * Canonical sybil-failure prefixes across credential types. Each prefix is the
+ * writer of a uniqueness/sybil rejection in its respective flow:
+ *
+ *   - 'User has already registered' — gov-id / KYC / clean-hands / zk-passport.
+ *     Canonical writer: `toAlreadyRegisteredStr` above. Used by Onfido v1/v2/v3,
+ *     Sumsub, Veriff, Idenfy, AML cross-provider, and zk-passport.
+ *   - 'Number has been registered already' — phone. Writer:
+ *     `failPhoneSession(..., 'Number has been registered already')` in
+ *     `services/phone/check-number.ts`.
+ *   - 'Face scan failed as highly matching duplicates are found' — biometrics.
+ *     Writer: FaceTec duplicate-match path in
+ *     `services/facetec/{credentials,v2/no-sybils/credentials,enrollment-3d}.js`.
+ *
+ * Keep this list in sync with new sybil writers. The frontend mirrors this in
+ * `frontend/src/hooks/holonym/misc.ts:isAlreadyRegisteredFailure`.
+ */
+const SYBIL_FAILURE_PREFIXES = [
+  'User has already registered',
+  'Number has been registered already',
+  'Face scan failed as highly matching duplicates are found'
+] as const
+
+/**
  * True iff the given verification-failure reason indicates a sybil/uniqueness
- * rejection (the "already registered" failure mode). Pinned to the canonical
- * writer `toAlreadyRegisteredStr` via prefix match.
+ * rejection across any credential type.
  */
 export function isAlreadyRegisteredFailure(reason: string | null | undefined): boolean {
-  return reason?.startsWith('User has already registered') ?? false
+  if (!reason) return false
+  return SYBIL_FAILURE_PREFIXES.some((p) => reason.startsWith(p))
 }
 
 export class CustomError extends Error {

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -4,6 +4,15 @@ export function toAlreadyRegisteredStr(userId: string) {
   return `User has already registered. User ID: ${userId}`
 }
 
+/**
+ * True iff the given verification-failure reason indicates a sybil/uniqueness
+ * rejection (the "already registered" failure mode). Pinned to the canonical
+ * writer `toAlreadyRegisteredStr` via prefix match.
+ */
+export function isAlreadyRegisteredFailure(reason: string | null | undefined): boolean {
+  return reason?.startsWith('User has already registered') ?? false
+}
+
 export class CustomError extends Error {
   userFacingMessage: string;
   logMessage: string;


### PR DESCRIPTION
## Summary

Adds two refund-eligibility guards to all four refund endpoints (gov-id, clean-hands, biometrics, phone), layered after the existing \`paymentCommitment + chainId\` check from #680:

- **Sybil guard** — sessions whose \`verificationFailureReason\` starts with \`"User has already registered"\` are no longer refundable. Detected via shared \`isAlreadyRegisteredFailure()\` helper, pinned to the canonical writer \`toAlreadyRegisteredStr\` by a round-trip unit test.
- **Window guard** — payment timestamp is read on-chain via \`getPaymentFromContract()\`; sessions whose payment is older than \`REFUND_WINDOW_SECONDS\` (7 days) are no longer refundable. "Payment not found on-chain" is treated as ineligible.

Each gate returns a distinct 400 message and emits a structured log line for support visibility. No DB changes — the on-chain \`payments(commitment).timestamp\` is the single source of truth for the window check.

Pairs with the matching frontend hook predicate in [holonym-foundation/human-id#fix/refund-sybil-stale-window](https://github.com/holonym-foundation/human-id/pull/new/fix/refund-sybil-stale-window).

Implements internal-docs issue #700. Plan: \`docs/plans/2026-04-30-007-fix-harden-refund-logic-against-sybils-plan.md\` in the human-id repo.

## Test plan

- [x] \`bun test src/utils/errors.test.ts\` — 4 round-trip cases for \`isAlreadyRegisteredFailure\` (canonical writer, prefix-only, unrelated reason, null/undefined/empty).
- [x] \`npx tsc --noEmit\` — clean.
- [ ] Manual: confirm a sybil-failed session returns \`400 "Refund not available for already-registered failures"\` from each of the four endpoints.
- [ ] Manual: confirm a session whose on-chain payment timestamp is >7 days old returns \`400 "Refund window has expired"\`.
- [ ] Manual: confirm a recent, non-sybil failed session still refunds successfully (no regression vs #680).

🤖 Generated with [Claude Code](https://claude.com/claude-code)