### PR TITLE
Upgrade @zkpassport/sdk to 0.15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@stellar/stellar-sdk": "^13.3.0",
     "@valkey/valkey-glide": "^2.0.1",
     "@verax-attestation-registry/verax-sdk": "^2.2.1",
-    "@zkpassport/sdk": "^0.14.2",
+    "@zkpassport/sdk": "^0.15.1",
     "aws-sdk": "^2.1295.0",
     "axios": "^1.13.2",
     "big-integer": "^1.6.51",

--- a/src/services/zk-passport/verify-and-issue.ts
+++ b/src/services/zk-passport/verify-and-issue.ts
@@ -45,7 +45,7 @@ const endpointLogger = logger.child({
 // The domain scopes proof validation and the uniqueIdentifier to the application.
 // We use the frontend domain (id.human.tech), NOT the server's own hostname.
 const zkPassportDomain = process.env.NODE_ENV === 'development' ? 'localhost' : "id.human.tech";
-const zkPassport = new ZKPassport(zkPassportDomain);
+const zkPassport = new ZKPassport(zkPassportDomain, { disableProofStorage: true });
 
 // SDK 0.14 requires verify() callers to pass the originalQuery so the SDK can
 // confirm the queryResult matches the server's expected disclosure set. The


### PR DESCRIPTION
## Summary
- Bumps `@zkpassport/sdk` from `^0.14.2` to `^0.15.1`.
- Constructs the SDK with `{ disableProofStorage: true }` so server-side `verify()` does not POST verified proofs to `dashboard-api.zkpassport.id`.

## Breaking-change review
0.15.0's only SDK API break (PR zkpassport/zkpassport-packages#201) removed `request({ policyId })` in favor of `.policy()`. We do not use `policyId`/`.policy()` anywhere, so our call sites (`createQuery().disclose().facematch().sanctions().done().query` and `verify({ proofs, originalQuery, queryResult })`) are unchanged.

New runtime behavior introduced in 0.15.x: `verify()` best-effort phones home to `dashboard-api.zkpassport.id` (project config GET + verified-proof POST). Disabled here via the new constructor option.

## Test plan
- [ ] CI typecheck passes
- [ ] Manual: run a ZK Passport gov-id verify-and-issue end-to-end in sandbox; confirm no outbound traffic to `dashboard-api.zkpassport.id`
- [ ] Manual: run a Clean Hands ZK Passport verify-and-issue in sandbox