### PR TITLE
prevent ECS crash on @aztec/bb.js native backend exit

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,8 +1,27 @@
 import { mongoose } from "./init.js";
 import { app } from "./index.js";
 import logger from "./utils/logger.js";
+import { makeUnknownErrorLoggable } from "./utils/errors.js";
 import { valkeyClient } from "./utils/valkey-glide.js";
 import type { Server } from "http";
+
+// Bun terminates on unhandled rejection by default. The @aztec/bb.js native
+// backend used by @zkpassport/sdk can reject its connectionPromise from a
+// child-process exit handler after the awaiter has already settled, which
+// escapes the verify() try/catch and kills the ECS task. Log and swallow so
+// one bb crash doesn't take down the server.
+process.on("unhandledRejection", (reason) => {
+  logger.error(
+    { error: makeUnknownErrorLoggable(reason) },
+    "unhandledRejection"
+  );
+});
+process.on("uncaughtException", (err) => {
+  logger.error(
+    { error: makeUnknownErrorLoggable(err) },
+    "uncaughtException"
+  );
+});
 
 const PORT = process.env.ENVIRONMENT == "dev" ? 3031 : 3000;
 const server: Server = app.listen(PORT, (err?: Error) => {


### PR DESCRIPTION
The bb child process spawned by @zkpassport/sdk can reject its connectionPromise from a child_process exit handler after the awaiter has settled, escaping the verify() try/catch and terminating the Bun process. Log unhandled rejections and uncaught exceptions instead of crashing the task.