### PR TITLE
upgrade base image to node:20-trixie-slim for @aztec/bb.js compatibility

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -1,6 +1,6 @@
 # TODO Multistage build?
 FROM zokrates/zokrates:0.8.2 AS zokrates
-FROM node:20.11.1-bullseye-slim
+FROM node:20-trixie-slim
 
 RUN apt-get update -y
 RUN apt-get install -y python3


### PR DESCRIPTION
The bb native binary spawned by @zkpassport/sdk's @aztec/bb.js (4.2.0-aztecnr-rc.2)
requires glibc >= 2.39 and libstdc++ >= 3.4.32. The previous base
(node:20.11.1-bullseye-slim, Debian 11, glibc 2.31, libstdc++ 3.4.28) is missing
GLIBC_2.32/2.33/2.34/2.38/2.39 and GLIBCXX_3.4.29/.30/.31/.32, so bb exits with
code 1 before main() runs and every ZK Passport verify fails. Bookworm is also
insufficient (glibc 2.36); trixie ships glibc 2.41 and links bb cleanly.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
