### PR TITLE
feat(aml): iDenfy as an Onfido-alternative branch for Clean Hands

### DIFF
--- a/src/routes/aml-sessions.ts
+++ b/src/routes/aml-sessions.ts
@@ -25,6 +25,8 @@ import {
   issueCredsV4Sandbox,
   verifyAndIssueZkPassport,
   verifyAndIssueZkPassportSandbox,
+  issueCredsIdenfyV4,
+  issueCredsIdenfyV4Sandbox,
   confirmStatement,
   confirmStatementSandbox,
   getSessions,
@@ -51,6 +53,7 @@ router.get("/:_id/credentials/:nullifier", issueCreds);
 router.get("/:_id/credentials/v2/:nullifier", issueCredsV2);
 router.get("/:_id/credentials/v3/:nullifier", issueCredsV3);
 router.get("/:_id/credentials/v4/:nullifier", issueCredsV4);
+router.get("/:_id/credentials/idenfy/v4/:nullifier", issueCredsIdenfyV4);
 router.post("/:_id/verify-and-issue", verifyAndIssueZkPassport);
 router.post("/:_id/statement/confirm", confirmStatement);
 
@@ -68,6 +71,7 @@ sandboxRouter.get("/", getSessionsSandbox);
 // sandboxRouter.post("/:_id/v3", payForSessionV3Sandbox);
 // sandboxRouter.post("/:_id/refund/v2", refundV2Sandbox);
 sandboxRouter.get("/:_id/credentials/v4/:nullifier", issueCredsV4Sandbox);
+sandboxRouter.get("/:_id/credentials/idenfy/v4/:nullifier", issueCredsIdenfyV4Sandbox);
 sandboxRouter.post("/:_id/verify-and-issue", verifyAndIssueZkPassportSandbox);
 sandboxRouter.post("/:_id/statement/confirm", confirmStatementSandbox);
 sandboxRouter.post("/:_id/refund", refundCleanHandsSessionSandbox);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -588,12 +588,18 @@ const amlChecksSessionSchema = new Schema<IAmlChecksSession>({
     type: Schema.Types.ObjectId,
     required: false,
   },
+  // Populated only when idvProvider === 'idenfy'. Points at the standalone
+  // IdenfySession row (scanRef/authToken/status), parallel to onfidoSessionId.
+  idenfySessionId: {
+    type: Schema.Types.ObjectId,
+    required: false,
+  },
   // Which identity-verification provider this AML session uses. Missing value
   // is treated as 'onfido' by callers so pre-existing documents keep their
   // original semantics. Enum-validated at the Mongoose layer.
   idvProvider: {
     type: String,
-    enum: ['onfido', 'zk-passport'],
+    enum: ['onfido', 'zk-passport', 'idenfy'],
     required: false,
   },
   // Populated only when idvProvider === 'zk-passport'. Holds fields disclosed
@@ -683,9 +689,13 @@ const sandboxAmlChecksSessionSchema = new Schema<ISandboxAmlChecksSession>({
     type: Schema.Types.ObjectId,
     required: false,
   },
+  idenfySessionId: {
+    type: Schema.Types.ObjectId,
+    required: false,
+  },
   idvProvider: {
     type: String,
-    enum: ['onfido', 'zk-passport'],
+    enum: ['onfido', 'zk-passport', 'idenfy'],
     required: false,
   },
   zkPassport: {

--- a/src/services/aml-sessions/endpoints.ts
+++ b/src/services/aml-sessions/endpoints.ts
@@ -79,7 +79,12 @@ import {
 import {
   createIdenfySession,
   findReusableIdenfySession,
+  getIdenfySessionById,
 } from "../idenfy-sessions/functions.js";
+import { fetchIdenfyStatus } from "../idenfy/status.js";
+import { fetchIdenfyVerificationData } from "../idenfy/data.js";
+import { extractIdenfyNameDob } from "../idenfy/credentials/utils.js";
+import { runSanctionsScreening } from "./sanctions-screening.js";
 import { getOnfidoCheck, getOnfidoReports } from "../../utils/onfido.js";
 import { validateCheck, validateReports, onfidoValidationToUserErrorMessage } from "../onfido/credentials/utils.js";
 import { ISanctionsResult } from "../../types.js";
@@ -2989,6 +2994,318 @@ async function verifyAndIssueZkPassportSandbox(req: Request, res: Response) {
   return createVerifyAndIssueZkPassportRouteHandler(config)(req, res);
 }
 
+const issueCredsIdenfyV4Logger = upgradeLogger(
+  logger.child({
+    msgPrefix: "[GET /aml-sessions/:_id/credentials/idenfy/v4/:nullifier] ",
+    base: {
+      ...pinoOptions.base,
+      feature: "holonym",
+      subFeature: "clean-hands",
+      idvProvider: "idenfy",
+    },
+  }),
+);
+
+/**
+ * GET /aml-sessions/:_id/credentials/idenfy/v4/:nullifier
+ *
+ * iDenfy branch of Clean Hands issuance. Server-polled (like the Onfido
+ * credentials/v4 endpoint, not the ZK Passport POST): the store page polls this
+ * until creds are ready. The handler re-confirms the iDenfy decision live via
+ * fetchIdenfyStatus (never trusting only the webhook-cached status), pulls
+ * name + DOB from the iDenfy data API, runs the shared sanctions/PEP screening,
+ * and issues Clean Hands creds in the same shape as the Onfido/ZK branches.
+ *
+ * Idempotent: a prior issuance for the same nullifier (within 5 days) re-issues
+ * the same creds instead of double-issuing, so repeated polls / racing tabs are
+ * safe.
+ */
+function createIssueCredsIdenfyV4RouteHandler(
+  config: SandboxVsLiveKYCRouteHandlerConfig,
+) {
+  return async (req: Request, res: Response) => {
+    try {
+      const _id = req.params._id;
+      const issuanceNullifier = req.params.nullifier;
+
+      // --- Validate request ---
+
+      if (!issuanceNullifier) {
+        return res.status(400).json({ error: "Missing nullifier (issuance nullifier)" });
+      }
+      try {
+        BigInt(issuanceNullifier);
+      } catch {
+        return res.status(400).json({
+          error: `Invalid issuance nullifier (${issuanceNullifier}). It must be a number`,
+        });
+      }
+
+      let objectId: ObjectId | null = null;
+      try {
+        objectId = new ObjectId(_id);
+      } catch {
+        return res.status(400).json({ error: "Invalid _id" });
+      }
+
+      // --- Load + gate the session ---
+
+      const session = await config.AMLChecksSessionModel.findOne({
+        _id: objectId,
+      }).exec();
+      if (!session) {
+        issueCredsIdenfyV4Logger.warn({ _id }, "Session not found");
+        return res.status(404).json({ error: "Session not found" });
+      }
+
+      if (session.idvProvider !== "idenfy") {
+        return res.status(400).json({
+          error: `Session idvProvider is '${session.idvProvider ?? "onfido"}'. This endpoint only handles 'idenfy' sessions.`,
+        });
+      }
+
+      if (session.status === sessionStatusEnum.VERIFICATION_FAILED) {
+        return res.status(400).json({
+          error: `Verification failed. Reason(s): ${session.verificationFailureReason}`,
+        });
+      }
+
+      if (session.status === cleanHandsSessionStatusEnum.NEEDS_USER_DECLARATION) {
+        return res.status(202).json({
+          message:
+            "User action required. User must confirm that they are not any of the PEPs mentioned in the results.",
+          statement: session?.userDeclaration?.statement,
+        });
+      }
+
+      // Allow IN_PROGRESS (fresh issuance) and ISSUED (recovery re-fetch). Any
+      // other status (e.g. NEEDS_PAYMENT) means the session is not paid — never
+      // issue from an unpaid session.
+      if (
+        session.status !== sessionStatusEnum.IN_PROGRESS &&
+        session.status !== sessionStatusEnum.ISSUED
+      ) {
+        return res.status(400).json({
+          error: `Session status is '${session.status}'. Expected '${sessionStatusEnum.IN_PROGRESS}' or '${sessionStatusEnum.ISSUED}'.`,
+        });
+      }
+
+      // --- Re-confirm the iDenfy decision live (not the webhook-cached status) ---
+
+      if (!session.idenfySessionId) {
+        issueCredsIdenfyV4Logger.error(
+          { sid: session._id },
+          "iDenfy AML session has no idenfySessionId",
+        );
+        return res.status(400).json({ error: "Session has no associated iDenfy session" });
+      }
+
+      const idenfySession = await getIdenfySessionById(config, session.idenfySessionId);
+      if (!idenfySession?.idenfyScanRef) {
+        return res.status(400).json({ error: "iDenfy session not found or missing scanRef" });
+      }
+      const scanRef = idenfySession.idenfyScanRef;
+
+      let idenfyStatus: string;
+      try {
+        const statusResp = await fetchIdenfyStatus({
+          scanRef,
+          sandbox: config.environment === "sandbox",
+        });
+        idenfyStatus = statusResp.status;
+      } catch (err: any) {
+        issueCredsIdenfyV4Logger.error(
+          { sid: session._id, scanRef, error: makeUnknownErrorLoggable(err) },
+          "Failed to fetch iDenfy status",
+        );
+        return res.status(502).json({ error: "Failed to verify iDenfy status" });
+      }
+
+      if (
+        idenfyStatus === "DENIED" ||
+        idenfyStatus === "SUSPECTED" ||
+        idenfyStatus === "EXPIRED"
+      ) {
+        await failSession(session, `iDenfy verification ${idenfyStatus}`);
+        return res.status(400).json({ error: `iDenfy verification ${idenfyStatus}` });
+      }
+
+      if (idenfyStatus !== "APPROVED") {
+        // ACTIVE / REVIEWING / null — keep polling.
+        return res.status(202).json({
+          message: "iDenfy verification still in progress",
+          status: idenfyStatus ?? null,
+        });
+      }
+
+      // --- Pull disclosed identity (name + DOB) ---
+
+      let idenfyData;
+      try {
+        idenfyData = await fetchIdenfyVerificationData({
+          scanRef,
+          sandbox: config.environment === "sandbox",
+        });
+      } catch (err: any) {
+        issueCredsIdenfyV4Logger.error(
+          { sid: session._id, scanRef, error: makeUnknownErrorLoggable(err) },
+          "Failed to fetch iDenfy verification data",
+        );
+        return res.status(502).json({ error: "Failed to fetch iDenfy verification data" });
+      }
+
+      const { firstName, lastName, dateOfBirth } = extractIdenfyNameDob(idenfyData);
+
+      // Reject empty PII: never run sanctions screening on an empty name (an
+      // empty-name query is a silent no-match — a bad-issuance path in AML).
+      if (!firstName || !lastName || !dateOfBirth) {
+        issueCredsIdenfyV4Logger.error(
+          { sid: session._id, firstName: !!firstName, lastName: !!lastName, dob: !!dateOfBirth },
+          "iDenfy verification data missing required identity fields",
+        );
+        await failSession(
+          session,
+          "iDenfy verification did not return required identity fields",
+        );
+        return res.status(400).json({
+          error: "iDenfy verification did not disclose firstName, lastName, and dateOfBirth.",
+        });
+      }
+
+      const uuid = govIdUUID(firstName, lastName, dateOfBirth);
+
+      // --- Idempotent recovery: same nullifier already issued within 5 days ---
+
+      const nullifierAndCreds = await findOneNullifierAndCredsLast5Days(
+        config.CleanHandsNullifierAndCredsModel,
+        issuanceNullifier,
+      );
+      if (nullifierAndCreds) {
+        const creds = extractCreds({ firstName, lastName, dateOfBirth });
+        const response = issuev2CleanHands(
+          config.cleanHandsIssuerPrivateKey,
+          issuanceNullifier,
+          creds,
+        );
+        response.metadata = creds;
+        if (session.status !== sessionStatusEnum.ISSUED) {
+          session.status = sessionStatusEnum.ISSUED;
+          try { await session.save(); } catch { /* non-fatal */ }
+        }
+        issueCredsIdenfyV4Logger.info(
+          { uuid, sid: session._id },
+          "Re-issuing Clean Hands credentials (iDenfy recovery branch)",
+        );
+        return res.status(200).json(response);
+      }
+
+      // --- Fresh issuance: session must be IN_PROGRESS (paid, not yet issued) ---
+
+      if (session.status !== sessionStatusEnum.IN_PROGRESS) {
+        return res.status(400).json({
+          error: `Session status is '${session.status}'. Expected '${sessionStatusEnum.IN_PROGRESS}' for fresh issuance.`,
+        });
+      }
+
+      // --- Shared sanctions.io / PEP screening ---
+
+      const screening = await runSanctionsScreening({
+        firstName,
+        lastName,
+        dateOfBirth,
+        session,
+        config,
+      });
+
+      if (screening.outcome === "blocked") {
+        await failSession(session, screening.failureReason);
+        return res.status(400).json({ error: "Sanctions match found" });
+      }
+
+      if (screening.outcome === "declaration-required") {
+        session.status = cleanHandsSessionStatusEnum.NEEDS_USER_DECLARATION;
+        session.userDeclaration = {
+          statement: screening.statement,
+          confirmed: false,
+          statementGeneratedAt: new Date(),
+        };
+        await session.save();
+        issueCredsIdenfyV4Logger.info(
+          { sessionId: session._id },
+          "Clean Hands session requires user declaration",
+        );
+        return res.status(202).json({
+          message:
+            "User action required. User must confirm that they are not any of the PEPs mentioned in the results.",
+          statement: screening.statement,
+        });
+      }
+
+      // --- Uniqueness check (11-month window) ---
+
+      if (config.environment === "live") {
+        const user = await findUserVerification(uuid, "aml", {
+          issuedAt: { after: dateElevenMonthsAgo() },
+          expiresAt: { after: new Date() },
+        });
+        if (user) {
+          issueCredsIdenfyV4Logger.alreadyRegistered(uuid);
+          await failSession(session, toAlreadyRegisteredStr(user._id.toString()));
+          return res
+            .status(400)
+            .json({ error: toAlreadyRegisteredStr(user._id.toString()) });
+        }
+      }
+
+      const dbResponse = await saveUserToDb(uuid);
+      if (dbResponse.error) return res.status(400).json(dbResponse);
+
+      // --- Issue credentials ---
+
+      const creds = extractCreds({ firstName, lastName, dateOfBirth });
+      const response = issuev2CleanHands(
+        config.cleanHandsIssuerPrivateKey,
+        issuanceNullifier,
+        creds,
+      );
+      response.metadata = creds;
+
+      const newNullifierAndCreds = new config.CleanHandsNullifierAndCredsModel({
+        holoUserId: session.sigDigest,
+        issuanceNullifier,
+        uuid,
+      });
+      await newNullifierAndCreds.save();
+
+      session.status = sessionStatusEnum.ISSUED;
+      await session.save();
+
+      issueCredsIdenfyV4Logger.info(
+        { uuid, sid: session._id },
+        "Issuing Clean Hands credentials (iDenfy branch)",
+      );
+
+      return res.status(200).json(response);
+    } catch (err: any) {
+      console.error(
+        "GET /aml-sessions/:_id/credentials/idenfy/v4/:nullifier: Error encountered",
+        makeUnknownErrorLoggable(err),
+      );
+      return res.status(500).json({ error: "An unknown error occurred" });
+    }
+  };
+}
+
+async function issueCredsIdenfyV4Live(req: Request, res: Response) {
+  const config = getRouteHandlerConfig("live");
+  return createIssueCredsIdenfyV4RouteHandler(config)(req, res);
+}
+
+async function issueCredsIdenfyV4Sandbox(req: Request, res: Response) {
+  const config = getRouteHandlerConfig("sandbox");
+  return createIssueCredsIdenfyV4RouteHandler(config)(req, res);
+}
+
 const confirmStatementLogger = logger.child({
   msgPrefix: "[POST /aml-sessions/:_id/statement/confirm] ",
   base: {
@@ -3267,6 +3584,8 @@ export {
   issueCredsV4Sandbox,
   verifyAndIssueZkPassportLive as verifyAndIssueZkPassport,
   verifyAndIssueZkPassportSandbox,
+  issueCredsIdenfyV4Live as issueCredsIdenfyV4,
+  issueCredsIdenfyV4Sandbox,
   confirmStatementLive as confirmStatement,
   confirmStatementSandbox,
   getSessionsLive as getSessions,

--- a/src/services/aml-sessions/endpoints.ts
+++ b/src/services/aml-sessions/endpoints.ts
@@ -76,6 +76,10 @@ import {
   createOnfidoSession,
   findReusableOnfidoSession,
 } from "../onfido-sessions/functions.js";
+import {
+  createIdenfySession,
+  findReusableIdenfySession,
+} from "../idenfy-sessions/functions.js";
 import { getOnfidoCheck, getOnfidoReports } from "../../utils/onfido.js";
 import { validateCheck, validateReports, onfidoValidationToUserErrorMessage } from "../onfido/credentials/utils.js";
 import { ISanctionsResult } from "../../types.js";
@@ -930,6 +934,9 @@ function createPayForSessionV4RouteHandler(config: SandboxVsLiveKYCRouteHandlerC
 
       // Missing idvProvider on legacy/pre-v4 docs is treated as 'onfido'.
       const idvProvider: IdvProvider = (session.idvProvider as IdvProvider) ?? "onfido";
+      // Pricing by provider: zk-passport is $3; onfido and idenfy are both the
+      // standard $5 Clean Hands verification service (idenfy is a drop-in
+      // replacement for the onfido gov-id-scan branch, so it reuses the price).
       const service =
         idvProvider === "zk-passport"
           ? PAYMENT_SERVICE_CLEAN_HANDS_ZK_PASSPORT_VERIFICATION
@@ -948,6 +955,7 @@ function createPayForSessionV4RouteHandler(config: SandboxVsLiveKYCRouteHandlerC
       session.chainId = chainIdNum;
 
       let onfidoSessionId: any = undefined;
+      let idenfySessionId: any = undefined;
       if (idvProvider === "onfido") {
         const reusable = await findReusableOnfidoSession(config, session.sigDigest!);
         if (reusable) {
@@ -971,6 +979,34 @@ function createPayForSessionV4RouteHandler(config: SandboxVsLiveKYCRouteHandlerC
             "Created new Onfido session for Clean Hands (v4)",
           );
         }
+      } else if (idvProvider === "idenfy") {
+        // Mirror the Onfido branch. Reuse is intentionally NOT scoped by flow
+        // (matches Onfido: a recent gov-id iDenfy verification is reused for
+        // Clean Hands), which is safe because the iDenfy issuance handler (U4)
+        // re-runs sanctions/PEP screening regardless of reuse — reuse only
+        // supplies the verified identity, never a sanctions pass.
+        const reusable = await findReusableIdenfySession(config, session.sigDigest!);
+        if (reusable) {
+          idenfySessionId = reusable._id;
+          session.idenfySessionId = reusable._id;
+          payForSessionV4Logger.info(
+            { sessionId: session._id, idenfySessionId: reusable._id },
+            "Reusing existing iDenfy session for Clean Hands (v4)",
+          );
+        } else {
+          const idenfySession = await createIdenfySession(
+            config,
+            session.sigDigest!,
+            "clean-hands",
+            session._id!,
+          );
+          idenfySessionId = idenfySession._id;
+          session.idenfySessionId = idenfySession._id;
+          payForSessionV4Logger.info(
+            { sessionId: session._id, idenfySessionId: idenfySession._id },
+            "Created new iDenfy session for Clean Hands (v4)",
+          );
+        }
       }
 
       await session.save();
@@ -982,7 +1018,7 @@ function createPayForSessionV4RouteHandler(config: SandboxVsLiveKYCRouteHandlerC
         config,
       });
 
-      return res.status(200).json({ session, onfidoSessionId });
+      return res.status(200).json({ session, onfidoSessionId, idenfySessionId });
     } catch (err: any) {
       if (reservationToken) {
         try {

--- a/src/services/aml-sessions/endpoints.ts
+++ b/src/services/aml-sessions/endpoints.ts
@@ -377,7 +377,7 @@ const postSessionsV4Logger = logger.child({
   },
 });
 
-const VALID_IDV_PROVIDERS = ["onfido", "zk-passport"] as const;
+const VALID_IDV_PROVIDERS = ["onfido", "zk-passport", "idenfy"] as const;
 type IdvProvider = (typeof VALID_IDV_PROVIDERS)[number];
 
 function resolveIdvProvider(raw: unknown): IdvProvider | null {

--- a/src/services/aml-sessions/sanctions-screening.test.ts
+++ b/src/services/aml-sessions/sanctions-screening.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+import { runSanctionsScreening } from "./sanctions-screening.js";
+
+// Stub SanctionsResult model: records nothing, just satisfies `new ...().save()`.
+class FakeSanctionsResult {
+  constructor(data: any) {
+    Object.assign(this, data);
+  }
+  async save() {}
+}
+const config = { SanctionsResultModel: FakeSanctionsResult } as any;
+
+const ORIGINAL_FETCH = globalThis.fetch;
+function mockFetch(results: any[]) {
+  const fn = mock(async () => ({ json: async () => ({ results }) }) as any);
+  globalThis.fetch = fn as any;
+  return fn;
+}
+
+describe("runSanctionsScreening", () => {
+  beforeEach(() => {
+    process.env.SANCTIONS_API_KEY = "test-key";
+  });
+  afterEach(() => {
+    globalThis.fetch = ORIGINAL_FETCH;
+  });
+
+  it("returns clear when sanctions.io returns no results", async () => {
+    mockFetch([]);
+    const decision = await runSanctionsScreening({
+      firstName: "John",
+      lastName: "Doe",
+      dateOfBirth: "1990-01-15",
+      session: { _id: "s1" } as any,
+      config,
+    });
+    expect(decision.outcome).toBe("clear");
+  });
+
+  it("requires a declaration for a PEP hit in a non-blocked country", async () => {
+    mockFetch([
+      {
+        data_source: { short_name: "PEP", name: "INT / PEP" },
+        si_identifier: "PEP-US-1", // US is not in siIdentifierPrefixesToBlock
+        data_hash: "hash-1",
+        name: "Jane Roe",
+        title: "Mayor",
+        confidence_score: 0.95,
+      },
+    ]);
+    const decision = await runSanctionsScreening({
+      firstName: "Jane",
+      lastName: "Roe",
+      dateOfBirth: "1980-03-02",
+      session: { _id: "s2" } as any,
+      config,
+    });
+    expect(decision.outcome).toBe("declaration-required");
+    if (decision.outcome === "declaration-required") {
+      expect(decision.statement).toContain("Jane Roe");
+    }
+  });
+
+  // NOTE: the `blocked` outcome path queries CleanHandsSessionWhitelist, a
+  // Mongoose model exported as a live binding from init.js that is only bound
+  // after a DB connection. Unit-testing it would require a Mongo bootstrap
+  // (none exists for aml-sessions today), so the block path is left to the
+  // production Onfido path it was copied from byte-for-byte. The block-vs-keep
+  // filtering itself is exercised by the declaration-required case above
+  // (which computes resultsToBlock === []).
+
+  it("skips screening (clear) when a recent declaration is confirmed", async () => {
+    const fetchSpy = mockFetch([]);
+    const decision = await runSanctionsScreening({
+      firstName: "John",
+      lastName: "Doe",
+      dateOfBirth: "1990-01-15",
+      session: {
+        _id: "s4",
+        userDeclaration: { confirmed: true, statementGeneratedAt: new Date() },
+      } as any,
+      config,
+    });
+    expect(decision.outcome).toBe("clear");
+    // No API call when the recent declaration short-circuits screening.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/aml-sessions/sanctions-screening.ts
+++ b/src/services/aml-sessions/sanctions-screening.ts
@@ -1,0 +1,200 @@
+import { HydratedDocument } from "mongoose";
+import { pinoOptions, logger } from "../../utils/logger.js";
+import { upgradeLogger } from "./error-logger.js";
+import { CleanHandsSessionWhitelist } from "../../init.js";
+import { siIdentifierPrefixesToBlock } from "../../utils/constants.js";
+import { parseStatementForUserCertification } from "../../utils/clean-hands-misc.js";
+import {
+  SandboxVsLiveKYCRouteHandlerConfig,
+  ISanctionsResult,
+  IAmlChecksSession,
+  ISandboxAmlChecksSession,
+} from "../../types.js";
+
+/**
+ * Shared sanctions.io + PEP screening for the AML (Clean Hands) flow.
+ *
+ * This is the canonical screening implementation. It is a faithful extraction
+ * of the inline block in issueCredsV4 (the production Onfido path) — the query
+ * params, PEP-blocking-by-country logic, SanctionsResult persistence, whitelist
+ * handling, and statement generation are byte-for-byte identical, so all
+ * branches that call it produce the same screening decisions.
+ *
+ * Currently consumed only by the iDenfy issuance handler. Migrating the Onfido
+ * (issueCredsV4) and ZK Passport (verifyAndIssueZkPassport) paths onto this
+ * module is deferred to a separate refactor PR so that this feature PR keeps
+ * those production paths zero-diff (see the iDenfy Clean Hands plan, U3 /
+ * Deferred to Follow-Up Work).
+ *
+ * Sanctions.io is queried on name + date_of_birth only. `country` is
+ * deliberately NOT an input — country_residence is not part of the query in
+ * any existing branch; the credential's country lives elsewhere.
+ *
+ * Side effects: persists PEP hits to SanctionsResultModel and logs matches.
+ * It does NOT mutate the session or write an HTTP response — the caller owns
+ * session lifecycle (failSession on `blocked`, set NEEDS_USER_DECLARATION +
+ * userDeclaration on `declaration-required`) and the HTTP status.
+ */
+
+const screeningLogger = upgradeLogger(
+  logger.child({
+    msgPrefix: "[aml sanctions-screening] ",
+    base: {
+      ...pinoOptions.base,
+      feature: "holonym",
+      subFeature: "clean-hands",
+    },
+  })
+);
+
+export type SanctionsScreeningDecision =
+  | { outcome: "clear" }
+  | { outcome: "blocked"; failureReason: string }
+  | { outcome: "declaration-required"; statement: string };
+
+export async function runSanctionsScreening(args: {
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  session: HydratedDocument<IAmlChecksSession | ISandboxAmlChecksSession>;
+  config: SandboxVsLiveKYCRouteHandlerConfig;
+}): Promise<SanctionsScreeningDecision> {
+  const { firstName, lastName, dateOfBirth, session, config } = args;
+
+  // If a sanctions check was recently done, the user was not on any blocklist,
+  // and they were flagged as a potential PEP in a non-high-risk country, the
+  // session carries a statement the user can confirm. If they confirmed it
+  // recently, skip re-screening.
+  const fiveDaysAgo = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000);
+  const skipSanctionsCheck =
+    session.userDeclaration?.confirmed &&
+    (session.userDeclaration?.statementGeneratedAt ?? 0) > fiveDaysAgo;
+
+  if (skipSanctionsCheck) {
+    return { outcome: "clear" };
+  }
+
+  // sanctions.io returns 301 if we query "<base-url>/search" but returns the
+  // actual result when we query "<base-url>/search/" (with trailing slash).
+  const sanctionsUrl =
+    "https://api.sanctions.io/search/" +
+    "?min_score=0.93" +
+    `&data_source=${encodeURIComponent(
+      "CAP,CCMC,CMIC,DPL,DTC,EL,FATF,FBI,FINCEN,FSE,INTERPOL,ISN,MEU,NONSDN,NS-MBS LIST,OFAC-COMPREHENSIVE,OFAC-MILITARY,OFAC-OTHERS,PEP,PLC,SDN,SSI,US-DOS-CRS"
+    )}` +
+    `&name=${encodeURIComponent(`${firstName} ${lastName}`)}` +
+    `&date_of_birth=${encodeURIComponent(dateOfBirth)}` +
+    "&entity_type=individual";
+  const reqConfig = {
+    headers: {
+      Accept: "application/json; version=2.2",
+      Authorization: "Bearer " + process.env.SANCTIONS_API_KEY,
+    },
+  };
+  const resp = await fetch(sanctionsUrl, reqConfig);
+  const data = await resp.json();
+
+  const resultsObjectsToStore: Array<
+    HydratedDocument<ISanctionsResult> & { message: string }
+  > = [];
+  const resultsToBlock = data.results.filter((result: any) => {
+    // Keep all non-PEP results
+    if (result?.data_source?.short_name !== "PEP") {
+      return true;
+    }
+
+    // Log and persist the PEP hit
+    const resultToLog = {
+      data_source: result.data_source,
+      nationality: result.nationality,
+      confidence_score: result.confidence_score,
+      si_identifier: result.si_identifier,
+    };
+    screeningLogger.info({ result: resultToLog }, "PEP result found");
+    const resultsObj = new config.SanctionsResultModel({
+      message: "PEP result found",
+      ...resultToLog,
+    });
+    resultsObjectsToStore.push(resultsObj);
+
+    // Block PEP results from certain countries
+    for (const prefix of siIdentifierPrefixesToBlock) {
+      if (!result.si_identifier) {
+        screeningLogger.warn({ result }, "No si_identifier found for PEP result");
+        return true;
+      }
+      if (result.si_identifier?.startsWith(prefix)) {
+        return true;
+      }
+    }
+
+    return false;
+  });
+
+  await Promise.all(resultsObjectsToStore.map((result) => result.save()));
+
+  // PEP results that don't trigger an automatic block. For countries we don't
+  // block, allow the user to declare they are not the PEP with a similar name.
+  const resultsThatRequireDeclaration = data.results.filter((result: any) => {
+    // Ignore all non-PEP results
+    if (result?.data_source?.short_name !== "PEP") {
+      return false;
+    }
+
+    // If data_hash is missing for some reason, include it. It should be present.
+    if (!result.data_hash) {
+      screeningLogger.error(
+        { result },
+        "Sanctions io PEP result is missing data_hash"
+      );
+      return true;
+    }
+
+    // If this PEP result is already in the results to block, ignore it
+    for (const resultToBlock of resultsToBlock) {
+      if (resultToBlock.data_hash && result.data_hash === resultToBlock.data_hash) {
+        return false;
+      } else if (!resultToBlock.data_hash) {
+        screeningLogger.error(
+          { result: resultToBlock },
+          "Sanctions io PEP result is missing data_hash"
+        );
+        return true;
+      }
+    }
+
+    return true;
+  });
+
+  if (resultsToBlock.length > 0) {
+    const whitelistItem = await CleanHandsSessionWhitelist.findOne({
+      sessionId: session._id,
+    }).exec();
+    if (!whitelistItem) {
+      screeningLogger.sanctionsMatchFound(data.results);
+      const confidenceScores = data?.results
+        ?.map((result: any) => {
+          return `(${result.data_source?.name}: ${result?.confidence_score})`;
+        })
+        .join(", ");
+      return {
+        outcome: "blocked",
+        failureReason: `Sanctions match found. Confidence scores: ${confidenceScores}`,
+      };
+    } else {
+      screeningLogger.info(
+        { sessionId: session._id },
+        "Ignoring sanctions match for whitelisted session"
+      );
+    }
+  }
+
+  if (resultsThatRequireDeclaration.length > 0) {
+    const statement = parseStatementForUserCertification(
+      resultsThatRequireDeclaration
+    );
+    return { outcome: "declaration-required", statement };
+  }
+
+  return { outcome: "clear" };
+}

--- a/src/services/idenfy/credentials/utils.test.ts
+++ b/src/services/idenfy/credentials/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { extractCreds } from "./utils.js";
+import { extractCreds, extractIdenfyNameDob } from "./utils.js";
 
 /**
  * Parity test: iDenfy extractCreds output must equal Onfido extractCreds for
@@ -106,6 +106,33 @@ describe("idenfy extractCreds", () => {
     // Hashes are computed deterministically from empty buffers — must still
     // be valid strings.
     expect(typeof result.derivedCreds.nameHash.value).toBe("string");
+  });
+
+  // extractIdenfyNameDob feeds the Clean Hands (AML) branch, whose empty-PII
+  // guard depends on it returning "" (not undefined) for missing fields.
+  describe("extractIdenfyNameDob", () => {
+    it("pulls name + dob from a flat payload", () => {
+      const r = extractIdenfyNameDob({
+        scanRef: "x",
+        docFirstName: "John",
+        docLastName: "Doe",
+        docDob: "1990-01-15",
+      } as any);
+      expect(r).toEqual({ firstName: "John", lastName: "Doe", dateOfBirth: "1990-01-15" });
+    });
+
+    it("pulls name + dob from a nested payload", () => {
+      const r = extractIdenfyNameDob({
+        scanRef: "x",
+        data: { docFirstName: "Jane", docLastName: "Roe", docDob: "1985-06-20" },
+      } as any);
+      expect(r).toEqual({ firstName: "Jane", lastName: "Roe", dateOfBirth: "1985-06-20" });
+    });
+
+    it("returns empty strings (not undefined) for missing fields", () => {
+      const r = extractIdenfyNameDob({ scanRef: "x" } as any);
+      expect(r).toEqual({ firstName: "", lastName: "", dateOfBirth: "" });
+    });
   });
 
   // Defensive: iDenfy's real /api/v2/data shape (flat vs nested under `data`)

--- a/src/services/idenfy/credentials/utils.test.ts
+++ b/src/services/idenfy/credentials/utils.test.ts
@@ -108,6 +108,39 @@ describe("idenfy extractCreds", () => {
     expect(typeof result.derivedCreds.nameHash.value).toBe("string");
   });
 
+  // Defensive: iDenfy's real /api/v2/data shape (flat vs nested under `data`)
+  // is unconfirmed (U11). extractCreds must read PII regardless. A nested
+  // payload must yield the SAME creds as the equivalent flat payload — proving
+  // we never silently emit empty PII if the real shape turns out to be nested.
+  it("reads document fields whether flat or nested under `data`", () => {
+    const flat = extractCreds({
+      scanRef: "abc",
+      docFirstName: "John",
+      docLastName: "Doe",
+      docDob: "1990-01-15",
+      docIssuingCountry: "USA",
+    } as any);
+
+    const nested = extractCreds({
+      scanRef: "abc",
+      data: {
+        docFirstName: "John",
+        docLastName: "Doe",
+        docDob: "1990-01-15",
+        docIssuingCountry: "USA",
+      },
+    } as any);
+
+    expect(nested.rawCreds.firstName).toBe("John");
+    expect(nested.rawCreds.lastName).toBe("Doe");
+    expect(nested.rawCreds.birthdate).toBe("1990-01-15");
+    // Same logical input → byte-identical derived hashes regardless of nesting.
+    expect(nested.derivedCreds.nameHash.value).toBe(flat.derivedCreds.nameHash.value);
+    expect(
+      nested.derivedCreds.nameDobCitySubdivisionZipStreetExpireHash.value
+    ).toBe(flat.derivedCreds.nameDobCitySubdivisionZipStreetExpireHash.value);
+  });
+
   // TODO(U11): once we have a captured Onfido extractCreds output for "John
   // Doe / 1990-01-15 / USA / no address", add a parity assertion comparing the
   // four derivedCreds hashes byte-for-byte. The hash composition is identical

--- a/src/services/idenfy/credentials/utils.ts
+++ b/src/services/idenfy/credentials/utils.ts
@@ -76,6 +76,25 @@ export type IdenfyVerificationData = {
 };
 
 /**
+ * iDenfy's /api/v2/data has been observed in documentation to present document
+ * fields either flat at the top level (docFirstName, docDob, …) OR nested under
+ * a `data` object, depending on account/endpoint. Until a real sandbox response
+ * is captured (U11), read defensively: prefer the nested `data` object when it
+ * is present and object-shaped, otherwise treat the payload itself as the field
+ * bag. This prevents silently issuing empty-PII credentials if the real shape
+ * turns out to be nested — which the falsy-country guard below would NOT catch.
+ */
+function idenfyDocFields(
+  idenfyData: IdenfyVerificationData
+): Record<string, unknown> {
+  const root = idenfyData as Record<string, unknown>;
+  if (root.data && typeof root.data === "object") {
+    return root.data as Record<string, unknown>;
+  }
+  return root;
+}
+
+/**
  * Extract credentials from an iDenfy verification payload, normalized to the
  * shape produced by Onfido's extractCreds (see services/onfido/credentials/utils.ts:291).
  *
@@ -83,9 +102,8 @@ export type IdenfyVerificationData = {
  * ZK circuits depend on it byte-for-byte.
  */
 export function extractCreds(idenfyData: IdenfyVerificationData) {
-  // /api/v2/data returns document fields flat at the top level
-  // (docFirstName, docLastName, docDob, etc.) — not nested under `data`.
-  const data = idenfyData as Record<string, unknown>;
+  // Document fields may be flat or nested under `data` (see idenfyDocFields).
+  const data = idenfyDocFields(idenfyData);
 
   // Country code parity with Onfido (services/onfido/credentials/utils.ts:292):
   // Onfido reads `issuing_country` from the document report, so iDenfy must
@@ -252,7 +270,7 @@ export function extractCreds(idenfyData: IdenfyVerificationData) {
  * Matches Onfido/Sumsub: sha256(firstName + lastName + dob).
  */
 export function uuidOldFromIdenfyData(idenfyData: IdenfyVerificationData) {
-  const data = idenfyData as Record<string, unknown>;
+  const data = idenfyDocFields(idenfyData);
   const firstName = (data.docFirstName as string) || "";
   const lastName = (data.docLastName as string) || "";
   const dob = (data.docDob as string) || "";
@@ -265,7 +283,7 @@ export function uuidOldFromIdenfyData(idenfyData: IdenfyVerificationData) {
  * shared govIdUUID function (cross-provider Sybil resistance).
  */
 export function uuidNewFromIdenfyData(idenfyData: IdenfyVerificationData) {
-  const data = idenfyData as Record<string, unknown>;
+  const data = idenfyDocFields(idenfyData);
   const firstName = (data.docFirstName as string) || "";
   const lastName = (data.docLastName as string) || "";
   const dob = (data.docDob as string) || "";

--- a/src/services/idenfy/credentials/utils.ts
+++ b/src/services/idenfy/credentials/utils.ts
@@ -266,6 +266,28 @@ export function extractCreds(idenfyData: IdenfyVerificationData) {
 }
 
 /**
+ * Pull just first name, last name, and DOB from an iDenfy verification payload.
+ *
+ * Used by the Clean Hands (AML) iDenfy branch, whose credential only needs
+ * name + DOB (no country/address). Reads document fields whether flat or nested
+ * (see idenfyDocFields). DOB is returned verbatim as iDenfy's `docDob`, which is
+ * documented as YYYY-MM-DD — the format getDateAsInt / sanctions screening
+ * require downstream.
+ */
+export function extractIdenfyNameDob(idenfyData: IdenfyVerificationData): {
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+} {
+  const data = idenfyDocFields(idenfyData);
+  return {
+    firstName: (data.docFirstName as string) || "",
+    lastName: (data.docLastName as string) || "",
+    dateOfBirth: (data.docDob as string) || "",
+  };
+}
+
+/**
  * Generate the legacy ("old") UUID from iDenfy verification data.
  * Matches Onfido/Sumsub: sha256(firstName + lastName + dob).
  */

--- a/src/services/session-status.ts
+++ b/src/services/session-status.ts
@@ -264,7 +264,14 @@ function createGetSessionStatusV2(config: SandboxVsLiveKYCRouteHandlerConfig) {
         return res.status(400).json({ error: "Invalid sid" });
       }
 
-      const ambiguousSession = await config.SessionModel.findOne({ _id: objectId }).exec();
+      // Gov-id flows live in SessionModel. Clean Hands (AML) sessions live in a
+      // separate collection but share the iDenfy status-resolution path (the
+      // shared /idenfy/verify page polls this endpoint with the AML session _id
+      // for the iDenfy Clean Hands branch). Fall back to the AML collection when
+      // the gov-id lookup misses so `provider=idenfy` resolves either kind.
+      const ambiguousSession: any =
+        (await config.SessionModel.findOne({ _id: objectId }).exec()) ??
+        (await config.AMLChecksSessionModel.findOne({ _id: objectId }).exec());
 
       if (!ambiguousSession) {
         return res.status(404).json({ error: "Session not found" });

--- a/src/types.ts
+++ b/src/types.ts
@@ -276,7 +276,7 @@ export type IAmlChecksSession = {
   // Which identity-verification provider this AML session uses. Missing value
   // is treated as 'onfido' so pre-existing documents keep their original
   // semantics. See docs/plans/2026-04-23-feat-zk-passport-clean-hands-flow-plan.md (U1).
-  idvProvider?: 'onfido' | 'zk-passport';
+  idvProvider?: 'onfido' | 'zk-passport' | 'idenfy';
   // Populated only when idvProvider === 'zk-passport'. Mirrors the fields we
   // need to reach parity with the Onfido branch for sanctions/PEP + issuance.
   zkPassport?: {


### PR DESCRIPTION
Adds iDenfy as a third identity-verification provider for the Clean Hands (AML) flow, as a drop-in replacement for the Onfido gov-id-scan branch. ZK Passport (NFC) is unchanged. Paired with the frontend PR in holonym-foundation/human-id (feat/idenfy-clean-hands).

## What changed
- **`idenfy` is a valid AML provider**: added to the AML `idvProvider` enum (live + sandbox schemas), `VALID_IDV_PROVIDERS`, and the `IAmlChecksSession` type; new `idenfySessionId` field. `resolveIdvProvider` accepts it with no change.
- **`payForSessionV4`**: creates/reuses an `IdenfySession` when `idvProvider==='idenfy'` (mirrors the Onfido branch), returns `idenfySessionId`, prices at \$5 (reuses `PAYMENT_SERVICE_CLEAN_HANDS_VERIFICATION`; zk-passport stays \$3). Reuse is intentionally not flow-scoped — matches Onfido; issuance always re-screens.
- **`runSanctionsScreening` module** (`services/aml-sessions/sanctions-screening.ts`): faithful extraction of the inline sanctions.io + PEP block from `issueCredsV4` — identical query params, PEP-block-by-country, `SanctionsResult` persistence, whitelist handling, and statement generation. Returns a decision; caller owns session/HTTP. Queries name + DOB only.
- **New issuance endpoint** `GET /aml-sessions/:_id/credentials/idenfy/v4/:nullifier` (+ sandbox): server-polls iDenfy (like the Onfido credentials endpoint). Guards: `idvProvider==='idenfy'`, paid (`IN_PROGRESS`) state, idempotent recovery (a prior issuance for the same nullifier re-issues instead of double-issuing). Re-confirms the decision **live** via `fetchIdenfyStatus` (not the webhook-cached status), pulls name+DOB via `extractIdenfyNameDob`, rejects empty PII before screening, runs `runSanctionsScreening`, issues Clean Hands creds in the same shape as Onfido/ZK.
- **`extractCreds` hardening**: now tolerates iDenfy `/api/v2/data` fields whether flat or nested under `data` (the real shape is unconfirmed — `TODO(U11)`); prevents silent empty-PII issuance. Also fixes the gov-id iDenfy flow.

## Production paths untouched
The Onfido (`issueCredsV4`) and ZK Passport (`verifyAndIssueZkPassport`) sanctions blocks are **not** migrated onto the new module in this PR (deferred refactor) — zero behavioral diff to production AML issuance.

## How to verify
- `bun test src/services/idenfy/ src/services/aml-sessions/` → green (incl. new `sanctions-screening.test.ts`, `extractCreds` dual-shape + `extractIdenfyNameDob` tests)
- `bun check:types` → clean
- The branch defaults to nobody on the frontend; reachable only via `?preferredProvider=idenfy` until a one-line flip.

## Not in scope / follow-ups
- Capture a real iDenfy `/api/v2/data` sandbox response and byte-compare against `extractCreds` (resolves the `TODO(U11)` markers).
- Migrate Onfido + ZK Passport onto `runSanctionsScreening` (separate refactor PR with characterization tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)