### PR TITLE
feat(idenfy): apply Human ID KYC branding theme to token sessions

### DIFF
--- a/src/services/idenfy/token.test.ts
+++ b/src/services/idenfy/token.test.ts
@@ -46,7 +46,10 @@ describe("createIdenfyToken", () => {
     expect(result.authToken).toBe("AUTH123");
     expect(result.scanRef).toBe("SCAN123");
     expect(capturedUrl).toBe("https://ivs.idenfy.com/api/v2/token");
-    expect(capturedBody).toEqual({ clientId: "client-1" });
+    expect(capturedBody).toEqual({
+      clientId: "client-1",
+      theme: "dd51a655-ecaa-47f4-8096-747cadad183f",
+    });
     const expected = `Basic ${Buffer.from("test-key:test-secret").toString("base64")}`;
     expect(capturedAuthHeader).toBe(expected);
   });

--- a/src/services/idenfy/token.ts
+++ b/src/services/idenfy/token.ts
@@ -7,6 +7,17 @@ import {
 } from "./http.js";
 
 /**
+ * UUID of the KYC branding theme applied to every iDenfy session so the hosted
+ * verification UI matches Human ID branding rather than iDenfy's stock look.
+ * Created in the iDenfy dashboard (Settings → KYC → Branding); the same ID must
+ * exist in both the live and sandbox iDenfy accounts. Sent as `theme` on
+ * /api/v2/token — iDenfy falls back to its built-in "Default" theme if omitted.
+ *
+ * @see https://documentation.idenfy.com/KYC/GeneratingIdentificationToken/
+ */
+const IDENFY_KYC_THEME_UUID = "dd51a655-ecaa-47f4-8096-747cadad183f";
+
+/**
  * iDenfy /api/v2/token request body.
  *
  * `clientId` is a partner-supplied identifier. iDenfy treats reused clientIds
@@ -19,10 +30,11 @@ import {
  */
 type CreateIdenfyTokenRequest = {
   clientId: string;
-  // TODO(impl): iDenfy's token endpoint accepts many optional fields
-  // (firstName, lastName, locale, country, expiryTime, tokenType,
-  // documents[], generateDigitString, etc.). Add as needed during integration
-  // testing — none are required for the minimal happy path.
+  /** UUID of the KYC branding theme to apply. @see IDENFY_KYC_THEME_UUID */
+  theme?: string;
+  // iDenfy's token endpoint accepts many other optional fields (firstName,
+  // lastName, locale, country, expiryTime, tokenType, documents[],
+  // generateDigitString, etc.). Add as needed — none are required.
 };
 
 export type IdenfyTokenResponse = {
@@ -62,7 +74,10 @@ export async function createIdenfyToken(args: {
     );
   }
 
-  const reqBody: CreateIdenfyTokenRequest = { clientId };
+  const reqBody: CreateIdenfyTokenRequest = {
+    clientId,
+    theme: IDENFY_KYC_THEME_UUID,
+  };
 
   try {
     const resp = await axios.post<IdenfyTokenResponse>(


### PR DESCRIPTION
## What

Pass our iDenfy KYC branding theme UUID as the `theme` parameter on `POST /api/v2/token` so the hosted iDenfy verification UI renders with Human ID branding (colors + logo) instead of iDenfy's stock look.

## Why

We recently shipped iDenfy in the gov-id and clean-hands flows, but the verify page still showed iDenfy's default branding. iDenfy's documented per-session override is the `theme` field (UUID from the dashboard Branding section); when omitted, iDenfy falls back to its built-in "Default" theme.

## How

- Added module constant `IDENFY_KYC_THEME_UUID` in `src/services/idenfy/token.ts`.
- Added optional `theme` to `CreateIdenfyTokenRequest` (replaces the old `TODO` note about optional fields).
- Set `theme: IDENFY_KYC_THEME_UUID` in the token request body.

Both the gov-id and clean-hands flows funnel through `createIdenfyToken`, so this single change covers both. No frontend changes needed — the theme is baked into the session server-side at token mint time.

## Notes / reviewer attention

- **Prod + sandbox scope:** the `theme` is sent on both live and sandbox token calls (the `sandbox` flag only switches API credentials, not the body). iDenfy themes are per-account, so this UUID must exist in **both** the live and sandbox iDenfy dashboards. If we want live-only, it's a one-line gate on the existing `sandbox` arg.
- **Verification:** generate one session and open the iframe to confirm the theme actually renders for the account in use.

## Test plan

- [ ] Sandbox: create an iDenfy session, open the iframe, confirm Human ID colors/logo render.
- [ ] Confirm the theme UUID exists in both live and sandbox accounts (or decide to gate to live-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)