### PR TITLE
fix(idenfy): recreate expired iDenfy session so users can resume verification

### DIFF
--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -108,6 +108,7 @@ const idenfySessionSchema = new Schema<IIdenfySession>({
   createdByFlow: { type: String, required: true },
   createdBySessionId: { type: Schema.Types.ObjectId, required: true },
   createdAt: { type: Date, default: Date.now },
+  recreationCount: { type: Number, default: 0 },
 });
 idenfySessionSchema.index({ sigDigest: 1 });
 idenfySessionSchema.index({ idenfyScanRef: 1 }, { sparse: true });
@@ -123,6 +124,7 @@ const sandboxIdenfySessionSchema = new Schema<ISandboxIdenfySession>({
   createdByFlow: { type: String, required: true },
   createdBySessionId: { type: Schema.Types.ObjectId, required: true },
   createdAt: { type: Date, default: Date.now },
+  recreationCount: { type: Number, default: 0 },
 });
 sandboxIdenfySessionSchema.index({ sigDigest: 1 });
 sandboxIdenfySessionSchema.index({ idenfyScanRef: 1 }, { sparse: true });

--- a/src/services/idenfy-sessions/functions.test.ts
+++ b/src/services/idenfy-sessions/functions.test.ts
@@ -80,7 +80,11 @@ afterEach(() => {
 
 // A fake config whose IdenfySessionModel records updates and can return a
 // re-read document for the lock-miss path.
-function makeConfig(environment: "sandbox" | "live", reReadDoc?: any) {
+function makeConfig(
+  environment: "sandbox" | "live",
+  reReadDoc?: any,
+  updateMatchedCount: number = 1
+) {
   const updates: Array<{ filter: any; update: any }> = [];
   return {
     config: {
@@ -88,7 +92,10 @@ function makeConfig(environment: "sandbox" | "live", reReadDoc?: any) {
       IdenfySessionModel: {
         updateOne: async (filter: any, update: any) => {
           updates.push({ filter, update });
-          return { modifiedCount: 1 };
+          return {
+            matchedCount: updateMatchedCount,
+            modifiedCount: updateMatchedCount,
+          };
         },
         findById: (_id: any) => ({
           exec: async () => (reReadDoc ? { toObject: () => reReadDoc } : null),
@@ -151,7 +158,7 @@ describe("getIdenfyStatusForSession — EXPIRED recovery", () => {
     expect(await tryAcquireIdenfyRecreateLock("idenfy-row-1", "live")).toBe(true);
   });
 
-  it("freshly fetched EXPIRED (no cached webhook state) recovers without persisting failed", async () => {
+  it("freshly fetched EXPIRED persists an EXPIRED sentinel, then recovers, never writing failed", async () => {
     statusToReturn = "EXPIRED";
     const { config, updates } = makeConfig("live");
     // no cached verification status -> falls through to /api/v2/status poll
@@ -162,9 +169,35 @@ describe("getIdenfyStatusForSession — EXPIRED recovery", () => {
 
     expect(tokenCalls).toBe(1);
     expect(result.idenfyAuthToken).toBe("AUTH_NEW_1");
-    // the only persisted update is the re-mint, never a status:"failed" write
-    expect(updates.length).toBe(1);
-    expect(updates[0].update.$set.status).toBe("in_progress");
+    // First write is the sentinel (verification-status only — NOT status:failed),
+    // so concurrent pollers + the cap short-circuit see authoritative state.
+    expect(updates[0].update.$set).toEqual({ idenfyVerificationStatus: "EXPIRED" });
+    // Second write is the re-mint.
+    expect(updates[1].update.$set.idenfyAuthToken).toBe("AUTH_NEW_1");
+    expect(updates[1].update.$set.status).toBe("in_progress");
+    // The row is never left in status:"failed".
+    expect(updates.some((u) => u.update.$set && u.update.$set.status === "failed")).toBe(false);
+  });
+
+  it("0-match re-mint returns persisted peer state, not the orphaned billed token", async () => {
+    // Simulate the TTL-overrun race: our updateOne matches 0 rows because a peer
+    // already re-minted and advanced the scanRef. The re-read returns the peer's
+    // fresh row; we must return THAT, not our just-minted (orphaned) token.
+    const peerRow = expiredSession({
+      idenfyVerificationStatus: null,
+      status: "in_progress",
+      idenfyAuthToken: "AUTH_PEER",
+      idenfyScanRef: "SCAN_PEER",
+      recreationCount: 1,
+    });
+    const { config } = makeConfig("live", peerRow, 0); // updateOne matchedCount = 0
+    const result: any = await getIdenfyStatusForSession(config, expiredSession());
+
+    expect(tokenCalls).toBe(1); // a token was minted (billed) ...
+    expect(result.idenfyAuthToken).toBe("AUTH_PEER"); // ... but we return the persisted peer token
+    expect(result.idenfyAuthToken).not.toBe("AUTH_NEW_1"); // never the orphaned one
+    // lock released even on the 0-match path
+    expect(await tryAcquireIdenfyRecreateLock("idenfy-row-1", "live")).toBe(true);
   });
 
   it("at the cap, returns EXPIRED and does NOT mint", async () => {
@@ -254,6 +287,18 @@ describe("getIdenfyStatusForSession — non-EXPIRED behavior unchanged", () => {
     );
     expect(tokenCalls).toBe(0);
     expect(result.idenfyVerificationStatus).toBe("DENIED");
+  });
+
+  it("cached SUSPECTED returns as-is, no recovery, no lock", async () => {
+    const { config, updates } = makeConfig("live");
+    const result: any = await getIdenfyStatusForSession(
+      config,
+      expiredSession({ idenfyVerificationStatus: "SUSPECTED", status: "failed" })
+    );
+    expect(tokenCalls).toBe(0);
+    expect(result.idenfyVerificationStatus).toBe("SUSPECTED");
+    expect(updates.length).toBe(0);
+    expect(lockStore.size).toBe(0);
   });
 
   it("non-terminal fetched status (ACTIVE) persists and returns without minting or locking", async () => {

--- a/src/services/idenfy-sessions/functions.test.ts
+++ b/src/services/idenfy-sessions/functions.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import axios from "axios";
+
+// ---------------------------------------------------------------------------
+// Controllable Valkey fake. functions.ts imports `valkeyClient` from
+// ../../utils/valkey-glide.js; bun:test has no jest-style auto-mock, so we
+// replace that module with a fake whose lock state we can manipulate per test.
+// The specifier matches the one functions.ts uses so both resolve to the same
+// module path.
+// ---------------------------------------------------------------------------
+const lockStore = new Set<string>();
+
+const fakeValkey = {
+  set: async (key: string, _val: string, opts: any) => {
+    if (opts?.conditionalSet === "onlyIfDoesNotExist") {
+      if (lockStore.has(key)) return null; // NX fails — lock already held
+      lockStore.add(key);
+      return "OK";
+    }
+    lockStore.add(key);
+    return "OK";
+  },
+  del: async (keys: string[]) => {
+    for (const k of keys) lockStore.delete(k);
+  },
+  exists: async (keys: string[]) => keys.filter((k) => lockStore.has(k)).length,
+};
+
+mock.module("../../utils/valkey-glide.js", () => ({ valkeyClient: fakeValkey }));
+
+const functions = await import("./functions.js");
+const {
+  getIdenfyStatusForSession,
+  tryAcquireIdenfyRecreateLock,
+  releaseIdenfyRecreateLock,
+} = functions;
+
+// ---------------------------------------------------------------------------
+// axios stub: createIdenfyToken hits /api/v2/token, fetchIdenfyStatus hits
+// /api/v2/status. Branch on URL. Counters let tests assert whether the
+// (billed) token mint was actually attempted.
+// ---------------------------------------------------------------------------
+let originalPost: typeof axios.post;
+let tokenCalls = 0;
+let statusToReturn: string | null = null; // value /api/v2/status returns
+let tokenShouldThrow = false;
+let mintedSeq = 0;
+
+beforeEach(() => {
+  originalPost = axios.post;
+  lockStore.clear();
+  tokenCalls = 0;
+  statusToReturn = null;
+  tokenShouldThrow = false;
+  mintedSeq = 0;
+  process.env.IDENFY_API_KEY = "test-key";
+  process.env.IDENFY_API_SECRET = "test-secret";
+  process.env.IDENFY_SANDBOX_API_KEY = "sandbox-key";
+  process.env.IDENFY_SANDBOX_API_SECRET = "sandbox-secret";
+
+  (axios as any).post = async (url: string) => {
+    if (url.endsWith("/api/v2/token")) {
+      tokenCalls += 1;
+      if (tokenShouldThrow) throw new Error("iDenfy token API down");
+      mintedSeq += 1;
+      return {
+        data: { authToken: `AUTH_NEW_${mintedSeq}`, scanRef: `SCAN_NEW_${mintedSeq}` },
+      };
+    }
+    if (url.endsWith("/api/v2/status")) {
+      return { data: { scanRef: "SCAN_OLD", status: statusToReturn } };
+    }
+    throw new Error(`unexpected axios.post to ${url}`);
+  };
+});
+
+afterEach(() => {
+  (axios as any).post = originalPost;
+});
+
+// A fake config whose IdenfySessionModel records updates and can return a
+// re-read document for the lock-miss path.
+function makeConfig(environment: "sandbox" | "live", reReadDoc?: any) {
+  const updates: Array<{ filter: any; update: any }> = [];
+  return {
+    config: {
+      environment,
+      IdenfySessionModel: {
+        updateOne: async (filter: any, update: any) => {
+          updates.push({ filter, update });
+          return { modifiedCount: 1 };
+        },
+        findById: (_id: any) => ({
+          exec: async () => (reReadDoc ? { toObject: () => reReadDoc } : null),
+        }),
+      },
+    } as any,
+    updates,
+  };
+}
+
+function expiredSession(overrides: Partial<any> = {}) {
+  return {
+    _id: "idenfy-row-1",
+    sigDigest: "sig",
+    idenfyAuthToken: "AUTH_OLD",
+    idenfyScanRef: "SCAN_OLD",
+    idenfyVerificationStatus: "EXPIRED",
+    status: "failed",
+    createdByFlow: "gov-id",
+    createdBySessionId: "parent-session-1",
+    recreationCount: 0,
+    ...overrides,
+  } as any;
+}
+
+describe("tryAcquireIdenfyRecreateLock / releaseIdenfyRecreateLock", () => {
+  it("first acquire succeeds, second (held) fails, release frees it", async () => {
+    expect(await tryAcquireIdenfyRecreateLock("row-1", "live")).toBe(true);
+    expect(await tryAcquireIdenfyRecreateLock("row-1", "live")).toBe(false);
+    await releaseIdenfyRecreateLock("row-1", "live");
+    expect(await tryAcquireIdenfyRecreateLock("row-1", "live")).toBe(true);
+  });
+
+  it("sandbox and live use distinct keys", async () => {
+    expect(await tryAcquireIdenfyRecreateLock("row-1", "live")).toBe(true);
+    // sandbox key is different, so it is still free
+    expect(await tryAcquireIdenfyRecreateLock("row-1", "sandbox")).toBe(true);
+  });
+});
+
+describe("getIdenfyStatusForSession — EXPIRED recovery", () => {
+  it("cached EXPIRED under cap mints a fresh session and returns it (not EXPIRED)", async () => {
+    const { config, updates } = makeConfig("live");
+    const result: any = await getIdenfyStatusForSession(config, expiredSession());
+
+    expect(tokenCalls).toBe(1);
+    expect(result.idenfyAuthToken).toBe("AUTH_NEW_1");
+    expect(result.idenfyScanRef).toBe("SCAN_NEW_1");
+    expect(result.status).toBe("in_progress");
+    expect(result.idenfyVerificationStatus).toBeNull();
+    expect(result.recreationCount).toBe(1);
+
+    // persisted: $set new token + $inc recreationCount, conditional on old scanRef
+    expect(updates.length).toBe(1);
+    expect(updates[0].update.$set.idenfyAuthToken).toBe("AUTH_NEW_1");
+    expect(updates[0].update.$inc).toEqual({ recreationCount: 1 });
+    expect(updates[0].filter.idenfyScanRef).toBe("SCAN_OLD");
+
+    // lock was released
+    expect(await tryAcquireIdenfyRecreateLock("idenfy-row-1", "live")).toBe(true);
+  });
+
+  it("freshly fetched EXPIRED (no cached webhook state) recovers without persisting failed", async () => {
+    statusToReturn = "EXPIRED";
+    const { config, updates } = makeConfig("live");
+    // no cached verification status -> falls through to /api/v2/status poll
+    const result: any = await getIdenfyStatusForSession(
+      config,
+      expiredSession({ idenfyVerificationStatus: undefined, status: "in_progress" })
+    );
+
+    expect(tokenCalls).toBe(1);
+    expect(result.idenfyAuthToken).toBe("AUTH_NEW_1");
+    // the only persisted update is the re-mint, never a status:"failed" write
+    expect(updates.length).toBe(1);
+    expect(updates[0].update.$set.status).toBe("in_progress");
+  });
+
+  it("at the cap, returns EXPIRED and does NOT mint", async () => {
+    const { config, updates } = makeConfig("live");
+    const result: any = await getIdenfyStatusForSession(
+      config,
+      expiredSession({ recreationCount: 10 })
+    );
+
+    expect(tokenCalls).toBe(0);
+    expect(result.idenfyVerificationStatus).toBe("EXPIRED");
+    expect(updates.length).toBe(0);
+  });
+
+  it("overshoot self-heals: recreationCount > cap still returns EXPIRED", async () => {
+    const { config } = makeConfig("live");
+    const result: any = await getIdenfyStatusForSession(
+      config,
+      expiredSession({ recreationCount: 11 })
+    );
+    expect(tokenCalls).toBe(0);
+    expect(result.idenfyVerificationStatus).toBe("EXPIRED");
+  });
+
+  it("lock-miss (peer minting) returns pending with the stale token withheld", async () => {
+    // Simulate a peer holding the lock for this row.
+    await tryAcquireIdenfyRecreateLock("idenfy-row-1", "live");
+    // Re-read still shows expired (peer hasn't written yet).
+    const { config } = makeConfig("live", expiredSession());
+    const result: any = await getIdenfyStatusForSession(config, expiredSession());
+
+    expect(tokenCalls).toBe(0); // did not mint a second session
+    expect(result.idenfyVerificationStatus).toBeNull(); // pending, not EXPIRED
+    expect(result.idenfyAuthToken).toBeNull(); // stale token withheld
+    expect(result.idenfyScanRef).toBeNull();
+  });
+
+  it("lock-miss returns the refreshed row when the peer already re-minted", async () => {
+    await tryAcquireIdenfyRecreateLock("idenfy-row-1", "live");
+    const refreshed = expiredSession({
+      idenfyVerificationStatus: null,
+      status: "in_progress",
+      idenfyAuthToken: "AUTH_PEER",
+      idenfyScanRef: "SCAN_PEER",
+      recreationCount: 1,
+    });
+    const { config } = makeConfig("live", refreshed);
+    const result: any = await getIdenfyStatusForSession(config, expiredSession());
+
+    expect(tokenCalls).toBe(0);
+    expect(result.idenfyAuthToken).toBe("AUTH_PEER");
+    expect(result.status).toBe("in_progress");
+  });
+
+  it("iDenfy token API error returns EXPIRED, does not mutate, and releases the lock", async () => {
+    tokenShouldThrow = true;
+    const { config, updates } = makeConfig("live");
+    const result: any = await getIdenfyStatusForSession(config, expiredSession());
+
+    expect(tokenCalls).toBe(1);
+    expect(result.idenfyVerificationStatus).toBe("EXPIRED");
+    expect(updates.length).toBe(0); // no row mutation on failure
+    // lock released despite the error
+    expect(await tryAcquireIdenfyRecreateLock("idenfy-row-1", "live")).toBe(true);
+  });
+});
+
+describe("getIdenfyStatusForSession — non-EXPIRED behavior unchanged", () => {
+  it("cached APPROVED returns as-is, no lock, no token call", async () => {
+    const { config, updates } = makeConfig("live");
+    const result: any = await getIdenfyStatusForSession(
+      config,
+      expiredSession({ idenfyVerificationStatus: "APPROVED", status: "complete" })
+    );
+    expect(tokenCalls).toBe(0);
+    expect(result.idenfyVerificationStatus).toBe("APPROVED");
+    expect(updates.length).toBe(0);
+    // no lock was taken for a plain status read
+    expect(lockStore.size).toBe(0);
+  });
+
+  it("cached DENIED returns as-is, no recovery", async () => {
+    const { config } = makeConfig("live");
+    const result: any = await getIdenfyStatusForSession(
+      config,
+      expiredSession({ idenfyVerificationStatus: "DENIED", status: "failed" })
+    );
+    expect(tokenCalls).toBe(0);
+    expect(result.idenfyVerificationStatus).toBe("DENIED");
+  });
+
+  it("non-terminal fetched status (ACTIVE) persists and returns without minting or locking", async () => {
+    statusToReturn = "ACTIVE";
+    const { config, updates } = makeConfig("live");
+    const result: any = await getIdenfyStatusForSession(
+      config,
+      expiredSession({ idenfyVerificationStatus: undefined, status: "in_progress" })
+    );
+    expect(tokenCalls).toBe(0);
+    expect(result.idenfyVerificationStatus).toBe("ACTIVE");
+    expect(updates.length).toBe(1);
+    expect(updates[0].update.$set.idenfyVerificationStatus).toBe("ACTIVE");
+    expect(lockStore.size).toBe(0); // no recreate lock for a plain poll
+  });
+
+  it("fetched APPROVED sets status complete", async () => {
+    statusToReturn = "APPROVED";
+    const { config, updates } = makeConfig("live");
+    const result: any = await getIdenfyStatusForSession(
+      config,
+      expiredSession({ idenfyVerificationStatus: undefined, status: "in_progress" })
+    );
+    expect(result.idenfyVerificationStatus).toBe("APPROVED");
+    expect(updates[0].update.$set.status).toBe("complete");
+  });
+});
+
+describe("getIdenfyStatusForSession — Clean Hands (AML) shares the same path", () => {
+  // The /session-status/v2 endpoint resolves both SessionModel (gov-id) and
+  // AMLChecksSessionModel (clean-hands) and calls getIdenfyStatusForSession for
+  // either — recovery keys on createdBySessionId, not the flow, so no code fork.
+  it("a clean-hands EXPIRED row recovers identically to gov-id", async () => {
+    const { config, updates } = makeConfig("live");
+    const result: any = await getIdenfyStatusForSession(
+      config,
+      expiredSession({
+        createdByFlow: "clean-hands",
+        createdBySessionId: "aml-session-1",
+      })
+    );
+
+    expect(tokenCalls).toBe(1);
+    expect(result.idenfyAuthToken).toBe("AUTH_NEW_1");
+    expect(result.status).toBe("in_progress");
+    expect(result.recreationCount).toBe(1);
+    expect(updates[0].update.$inc).toEqual({ recreationCount: 1 });
+  });
+
+  it("recreating one flow's row does not touch another row's lock", async () => {
+    const govConfig = makeConfig("live");
+    await getIdenfyStatusForSession(
+      govConfig.config,
+      expiredSession({ _id: "gov-row", createdBySessionId: "gov-parent" })
+    );
+
+    // The gov row's lock was acquired and released; a clean-hands row with a
+    // different _id is independently lockable.
+    expect(await tryAcquireIdenfyRecreateLock("gov-row", "live")).toBe(true);
+    expect(await tryAcquireIdenfyRecreateLock("ch-row", "live")).toBe(true);
+  });
+});

--- a/src/services/idenfy-sessions/functions.ts
+++ b/src/services/idenfy-sessions/functions.ts
@@ -1,4 +1,5 @@
 import { Types } from "mongoose";
+import { TimeUnit } from "@valkey/valkey-glide";
 import { pinoOptions, logger } from "../../utils/logger.js";
 import {
   IIdenfySession,
@@ -7,6 +8,7 @@ import {
 } from "../../types.js";
 import { createIdenfyToken } from "../idenfy/token.js";
 import { fetchIdenfyStatus } from "../idenfy/status.js";
+import { valkeyClient } from "../../utils/valkey-glide.js";
 
 const idenfySessionLogger = logger.child({
   msgPrefix: "[iDenfy Sessions] ",
@@ -90,22 +92,202 @@ export async function getIdenfySessionById(
   return config.IdenfySessionModel.findById(id).exec();
 }
 
-// iDenfy reports these as the final decision on /api/v2/status (and webhook).
+// Max number of fresh iDenfy sessions we will mint for a single IdenfySession row
+// after EXPIRED. iDenfy bills per session ("each session consumes a verification
+// credit"), so this bounds cost/abuse. Beyond the cap we stop re-creating and
+// surface EXPIRED (the existing dead-end UI + manual support path).
+const IDENFY_RECREATE_CAP = 10;
+
+// TTL for the Valkey lock that serializes the iDenfy token API call across
+// concurrent pollers. Long enough to cover the /api/v2/token request (10s
+// timeout) + the row update, short enough to auto-release if a process dies
+// mid-mint.
+const IDENFY_RECREATE_LOCK_TTL_SECONDS = 30;
+
+function idenfyRecreateLockKey(
+  idenfySessionId: string | Types.ObjectId,
+  environment: "sandbox" | "live"
+): string {
+  const prefix = environment === "sandbox" ? "sandbox:" : "";
+  return `${prefix}idenfy:recreate-lock:${idenfySessionId}`;
+}
+
+/**
+ * Atomically attempt to acquire the per-row iDenfy re-creation lock. Returns
+ * true if acquired, false if another caller already holds it. Mirrors the
+ * SET-NX pattern used by tryAcquireRedemptionPending. Acquired ONLY around the
+ * iDenfy token API call — never for plain status reads.
+ */
+export async function tryAcquireIdenfyRecreateLock(
+  idenfySessionId: string | Types.ObjectId,
+  environment: "sandbox" | "live"
+): Promise<boolean> {
+  if (!valkeyClient) {
+    throw new Error("Valkey client not initialized");
+  }
+  const key = idenfyRecreateLockKey(idenfySessionId, environment);
+  const result = await valkeyClient.set(key, "1", {
+    conditionalSet: "onlyIfDoesNotExist",
+    expiry: { type: TimeUnit.Seconds, count: IDENFY_RECREATE_LOCK_TTL_SECONDS },
+  });
+  return result !== null;
+}
+
+/**
+ * Release the per-row iDenfy re-creation lock.
+ */
+export async function releaseIdenfyRecreateLock(
+  idenfySessionId: string | Types.ObjectId,
+  environment: "sandbox" | "live"
+): Promise<void> {
+  if (!valkeyClient) {
+    throw new Error("Valkey client not initialized");
+  }
+  const key = idenfyRecreateLockKey(idenfySessionId, environment);
+  await valkeyClient.del([key]);
+}
+
+// iDenfy reports these as a final, non-recoverable decision on /api/v2/status
+// (and webhook). They are cached and returned as-is. EXPIRED is deliberately
+// NOT in this set: it is recoverable (the token's session window lapsed before
+// the user finished), so it routes into recreateExpiredIdenfySession instead.
 // Anything else (ACTIVE, REVIEWING, null) is in-progress — keep polling.
 const IDENFY_TERMINAL_STATUSES = new Set([
   "APPROVED",
   "DENIED",
   "SUSPECTED",
-  "EXPIRED",
 ]);
+
+/**
+ * Mint a fresh iDenfy session for a row whose previous session EXPIRED, reusing
+ * the same parent flow session (clientId = createdBySessionId) so the user does
+ * NOT pay again. The fresh authToken/scanRef overwrite the row in place and the
+ * status resets to in_progress; recreationCount is incremented.
+ *
+ * Anti-flash contract — this NEVER returns EXPIRED while re-creation is viable,
+ * because the frontend's `expired` flag is sticky and one EXPIRED response would
+ * dead-end the page:
+ *   - recreationCount >= cap        -> return EXPIRED (genuine give-up)
+ *   - lock acquired + mint ok       -> return fresh row (in_progress, new token)
+ *   - lock acquired + iDenfy error  -> return EXPIRED (actionable fallback)
+ *   - lock NOT acquired (peer mint) -> re-read; return fresh if refreshed, else
+ *                                      return a pending status with the stale
+ *                                      token withheld so the frontend keeps
+ *                                      polling (never EXPIRED).
+ *
+ * The Valkey lock is held ONLY around the iDenfy token API call so concurrent
+ * pollers (the host verify page and the external popup poll independently) mint
+ * at most one fresh session per expiry under normal timing.
+ */
+async function recreateExpiredIdenfySession(
+  config: SandboxVsLiveKYCRouteHandlerConfig,
+  idenfySession: IIdenfySession | ISandboxIdenfySession
+): Promise<IIdenfySession | ISandboxIdenfySession> {
+  const env = config.environment;
+  const id = idenfySession._id!;
+  const currentCount = idenfySession.recreationCount ?? 0;
+
+  // Cap reached — stop minting, surface EXPIRED (existing dead-end UI).
+  if (currentCount >= IDENFY_RECREATE_CAP) {
+    idenfySessionLogger.info(
+      { idenfySessionId: id, recreationCount: currentCount },
+      "iDenfy recreate cap reached — returning EXPIRED"
+    );
+    return {
+      ...idenfySession,
+      idenfyVerificationStatus: "EXPIRED",
+    } as IIdenfySession | ISandboxIdenfySession;
+  }
+
+  const acquired = await tryAcquireIdenfyRecreateLock(id, env);
+
+  if (!acquired) {
+    // A peer poller is re-creating. Re-read the row: return it if already
+    // refreshed; otherwise return a pending status with the stale (expired)
+    // token withheld so the frontend shows "Preparing verification…" instead
+    // of flashing the sticky expired screen.
+    const refreshed = await getIdenfySessionById(config, id);
+    const refreshedObj = (refreshed ? refreshed.toObject() : idenfySession) as
+      | IIdenfySession
+      | ISandboxIdenfySession;
+
+    if (
+      refreshedObj.idenfyVerificationStatus !== "EXPIRED" &&
+      refreshedObj.status === "in_progress"
+    ) {
+      return refreshedObj;
+    }
+
+    return {
+      ...refreshedObj,
+      idenfyVerificationStatus: null,
+      verificationFailureReason: null,
+      idenfyAuthToken: null,
+      idenfyScanRef: null,
+    } as unknown as IIdenfySession | ISandboxIdenfySession;
+  }
+
+  try {
+    const tokenData = await createIdenfyToken({
+      clientId: idenfySession.createdBySessionId.toString(),
+      sandbox: env === "sandbox",
+    });
+
+    const update = {
+      idenfyAuthToken: tokenData.authToken,
+      idenfyScanRef: tokenData.scanRef,
+      status: "in_progress",
+      idenfyVerificationStatus: null,
+      verificationFailureReason: null,
+    };
+
+    // Conditional on the OLD scanRef so a concurrent webhook write for the
+    // expired session can't be clobbered ambiguously — we only update the row
+    // we actually read.
+    await config.IdenfySessionModel.updateOne(
+      { _id: id, idenfyScanRef: idenfySession.idenfyScanRef },
+      { $set: update, $inc: { recreationCount: 1 } }
+    );
+
+    idenfySessionLogger.info(
+      {
+        idenfySessionId: id,
+        newScanRef: tokenData.scanRef,
+        recreationCount: currentCount + 1,
+      },
+      "Recreated expired iDenfy session"
+    );
+
+    return {
+      ...idenfySession,
+      ...update,
+      recreationCount: currentCount + 1,
+    } as unknown as IIdenfySession | ISandboxIdenfySession;
+  } catch (err: any) {
+    idenfySessionLogger.error(
+      { idenfySessionId: id, error: err?.message },
+      "iDenfy session re-creation failed — returning EXPIRED"
+    );
+    return {
+      ...idenfySession,
+      idenfyVerificationStatus: "EXPIRED",
+    } as IIdenfySession | ISandboxIdenfySession;
+  } finally {
+    await releaseIdenfyRecreateLock(id, env);
+  }
+}
 
 /**
  * Resolve the verification status for an iDenfy session.
  *
  * Polls iDenfy's `/api/v2/status` whenever the persisted status is empty OR
- * non-terminal (ACTIVE / REVIEWING). Once a terminal value is set
- * (APPROVED/DENIED/SUSPECTED/EXPIRED) — either by the webhook or a previous
- * poll — we stop hitting the API and return the cached row.
+ * non-terminal (ACTIVE / REVIEWING). Truly-terminal values
+ * (APPROVED/DENIED/SUSPECTED) — set by the webhook or a previous poll — are
+ * returned from cache without hitting the API.
+ *
+ * EXPIRED is recoverable, not terminal: whether it arrives cached (webhook) or
+ * from a fresh /api/v2/status poll, it routes into recreateExpiredIdenfySession
+ * which mints a fresh iDenfy session for the same (already-paid) parent session.
  */
 export async function getIdenfyStatusForSession(
   config: SandboxVsLiveKYCRouteHandlerConfig,
@@ -113,11 +295,16 @@ export async function getIdenfyStatusForSession(
 ) {
   if (!idenfySession) return null;
 
-  if (
-    idenfySession.idenfyVerificationStatus &&
-    IDENFY_TERMINAL_STATUSES.has(idenfySession.idenfyVerificationStatus)
-  ) {
+  const cachedStatus = idenfySession.idenfyVerificationStatus;
+
+  // Cached truly-terminal status (APPROVED/DENIED/SUSPECTED) — return as-is.
+  if (cachedStatus && IDENFY_TERMINAL_STATUSES.has(cachedStatus)) {
     return idenfySession;
+  }
+
+  // Cached EXPIRED (e.g. set by the webhook) — recover rather than dead-end.
+  if (cachedStatus === "EXPIRED") {
+    return recreateExpiredIdenfySession(config, idenfySession);
   }
 
   if (!idenfySession.idenfyScanRef) {
@@ -130,15 +317,20 @@ export async function getIdenfyStatusForSession(
       sandbox: config.environment === "sandbox",
     });
     if (data.status) {
+      // Freshly fetched EXPIRED — route into recovery WITHOUT first persisting
+      // status:"failed" (that would re-cache EXPIRED and read as a dead-end).
+      if (data.status === "EXPIRED") {
+        return recreateExpiredIdenfySession(config, {
+          ...idenfySession,
+          idenfyVerificationStatus: "EXPIRED",
+        } as IIdenfySession | ISandboxIdenfySession);
+      }
+
       const update: Record<string, unknown> = {
         idenfyVerificationStatus: data.status,
       };
       if (data.status === "APPROVED") update.status = "complete";
-      else if (
-        data.status === "DENIED" ||
-        data.status === "SUSPECTED" ||
-        data.status === "EXPIRED"
-      ) {
+      else if (data.status === "DENIED" || data.status === "SUSPECTED") {
         update.status = "failed";
       }
 

--- a/src/services/idenfy-sessions/functions.ts
+++ b/src/services/idenfy-sessions/functions.ts
@@ -4,6 +4,7 @@ import { pinoOptions, logger } from "../../utils/logger.js";
 import {
   IIdenfySession,
   ISandboxIdenfySession,
+  IdenfySessionView,
   SandboxVsLiveKYCRouteHandlerConfig,
 } from "../../types.js";
 import { createIdenfyToken } from "../idenfy/token.js";
@@ -182,10 +183,23 @@ const IDENFY_TERMINAL_STATUSES = new Set([
 async function recreateExpiredIdenfySession(
   config: SandboxVsLiveKYCRouteHandlerConfig,
   idenfySession: IIdenfySession | ISandboxIdenfySession
-): Promise<IIdenfySession | ISandboxIdenfySession> {
+): Promise<IdenfySessionView> {
   const env = config.environment;
   const id = idenfySession._id!;
   const currentCount = idenfySession.recreationCount ?? 0;
+
+  // Pending shape returned when we must withhold the stale token (lock-miss or
+  // a row that moved under us). Frontend treats null status as "preparing".
+  const pending = (
+    base: IIdenfySession | ISandboxIdenfySession
+  ): IdenfySessionView =>
+    ({
+      ...base,
+      idenfyVerificationStatus: null,
+      verificationFailureReason: null,
+      idenfyAuthToken: null,
+      idenfyScanRef: null,
+    }) as IdenfySessionView;
 
   // Cap reached — stop minting, surface EXPIRED (existing dead-end UI).
   if (currentCount >= IDENFY_RECREATE_CAP) {
@@ -196,7 +210,7 @@ async function recreateExpiredIdenfySession(
     return {
       ...idenfySession,
       idenfyVerificationStatus: "EXPIRED",
-    } as IIdenfySession | ISandboxIdenfySession;
+    } as IdenfySessionView;
   }
 
   const acquired = await tryAcquireIdenfyRecreateLock(id, env);
@@ -218,13 +232,7 @@ async function recreateExpiredIdenfySession(
       return refreshedObj;
     }
 
-    return {
-      ...refreshedObj,
-      idenfyVerificationStatus: null,
-      verificationFailureReason: null,
-      idenfyAuthToken: null,
-      idenfyScanRef: null,
-    } as unknown as IIdenfySession | ISandboxIdenfySession;
+    return pending(refreshedObj);
   }
 
   try {
@@ -233,7 +241,7 @@ async function recreateExpiredIdenfySession(
       sandbox: env === "sandbox",
     });
 
-    const update = {
+    const update: Partial<IdenfySessionView> = {
       idenfyAuthToken: tokenData.authToken,
       idenfyScanRef: tokenData.scanRef,
       status: "in_progress",
@@ -244,10 +252,25 @@ async function recreateExpiredIdenfySession(
     // Conditional on the OLD scanRef so a concurrent webhook write for the
     // expired session can't be clobbered ambiguously — we only update the row
     // we actually read.
-    await config.IdenfySessionModel.updateOne(
+    const updateRes = await config.IdenfySessionModel.updateOne(
       { _id: id, idenfyScanRef: idenfySession.idenfyScanRef },
       { $set: update, $inc: { recreationCount: 1 } }
     );
+
+    // The row moved under us between read and write — e.g. the lock TTL expired
+    // mid-mint and a second poller already persisted a fresh session. Our
+    // just-minted token was never recorded (its webhook would 404), so do NOT
+    // return it as success. Return whatever actually landed in the DB instead.
+    if (updateRes.matchedCount === 0) {
+      idenfySessionLogger.warn(
+        { idenfySessionId: id, oldScanRef: idenfySession.idenfyScanRef },
+        "iDenfy re-mint matched no row (concurrent re-mint?) — returning persisted state, not the orphaned token"
+      );
+      const persisted = await getIdenfySessionById(config, id);
+      return persisted
+        ? (persisted.toObject() as IdenfySessionView)
+        : pending(idenfySession);
+    }
 
     idenfySessionLogger.info(
       {
@@ -262,7 +285,7 @@ async function recreateExpiredIdenfySession(
       ...idenfySession,
       ...update,
       recreationCount: currentCount + 1,
-    } as unknown as IIdenfySession | ISandboxIdenfySession;
+    } as IdenfySessionView;
   } catch (err: any) {
     idenfySessionLogger.error(
       { idenfySessionId: id, error: err?.message },
@@ -271,7 +294,7 @@ async function recreateExpiredIdenfySession(
     return {
       ...idenfySession,
       idenfyVerificationStatus: "EXPIRED",
-    } as IIdenfySession | ISandboxIdenfySession;
+    } as IdenfySessionView;
   } finally {
     await releaseIdenfyRecreateLock(id, env);
   }
@@ -292,7 +315,7 @@ async function recreateExpiredIdenfySession(
 export async function getIdenfyStatusForSession(
   config: SandboxVsLiveKYCRouteHandlerConfig,
   idenfySession: IIdenfySession | ISandboxIdenfySession | null | undefined
-) {
+): Promise<IdenfySessionView | null> {
   if (!idenfySession) return null;
 
   const cachedStatus = idenfySession.idenfyVerificationStatus;
@@ -317,9 +340,17 @@ export async function getIdenfyStatusForSession(
       sandbox: config.environment === "sandbox",
     });
     if (data.status) {
-      // Freshly fetched EXPIRED — route into recovery WITHOUT first persisting
-      // status:"failed" (that would re-cache EXPIRED and read as a dead-end).
+      // Freshly fetched EXPIRED (no webhook fired). Persist the EXPIRED sentinel
+      // — verification-status only, NOT status:"failed" — BEFORE recovery so
+      // concurrent pollers and the cap short-circuit see authoritative state.
+      // Without it, a lock-losing peer would re-read an in_progress row and hand
+      // back the stale expired token, and a capped row would re-hit
+      // /api/v2/status on every poll.
       if (data.status === "EXPIRED") {
+        await config.IdenfySessionModel.updateOne(
+          { _id: idenfySession._id },
+          { $set: { idenfyVerificationStatus: "EXPIRED" } }
+        );
         return recreateExpiredIdenfySession(config, {
           ...idenfySession,
           idenfyVerificationStatus: "EXPIRED",
@@ -342,7 +373,7 @@ export async function getIdenfyStatusForSession(
       return {
         ...idenfySession,
         ...update,
-      } as IIdenfySession | ISandboxIdenfySession;
+      } as IdenfySessionView;
     }
   } catch (err: any) {
     idenfySessionLogger.warn(

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,7 @@ export type IIdenfySession = {
   createdByFlow: string;                 // 'gov-id' | 'clean-hands'
   createdBySessionId: Types.ObjectId;
   createdAt: Date;
+  recreationCount?: number;              // # of fresh iDenfy sessions minted for this row after EXPIRED; capped at 10
 };
 
 export type ISandboxIdenfySession = IIdenfySession;

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,24 @@ export type IIdenfySession = {
 
 export type ISandboxIdenfySession = IIdenfySession;
 
+// Shape returned by getIdenfyStatusForSession / recreateExpiredIdenfySession.
+// The resolver legitimately returns rows whose token fields are null during the
+// EXPIRED-recovery window (the lock-miss "pending" branch withholds the stale
+// token), so those fields are widened to `string | null` here instead of being
+// cast away. Callers already coalesce with `?? null`.
+export type IdenfySessionView = Omit<
+  IIdenfySession,
+  | "idenfyAuthToken"
+  | "idenfyScanRef"
+  | "idenfyVerificationStatus"
+  | "verificationFailureReason"
+> & {
+  idenfyAuthToken: string | null;
+  idenfyScanRef: string | null;
+  idenfyVerificationStatus?: string | null;
+  verificationFailureReason?: string | null;
+};
+
 // ---------------- MongoDB schemas ----------------
 
 export type IUserVerifications = {


### PR DESCRIPTION
## Summary

Fixes the iDenfy expired-session resume loop ([internal-docs#1343](https://github.com/holonym-foundation/internal-docs/issues/1343)). When an iDenfy verification token EXPIRES, the parent `Session` stays `IN_PROGRESS`, so the frontend keeps routing the user back to the same dead `/idenfy/verify` token — with no self-serve recovery. This makes the backend lazily mint a **fresh** iDenfy session for the same already-paid parent session on the next status poll.

Backend half. Frontend half + submodule bump is in the monorepo PR.

## Changes

- **`getIdenfyStatusForSession`** now treats `EXPIRED` as recoverable (not terminal), from both the cached-webhook path and a fresh `/api/v2/status` poll. It routes into `recreateExpiredIdenfySession`, which re-mints in place (new `authToken`/`scanRef`, `status` → `in_progress`) reusing `clientId = createdBySessionId` — **no new payment/redemption** (verified against iDenfy docs: same clientId mints a fresh session).
- **Anti-flash contract:** never surface `EXPIRED` while re-creation is viable (the frontend's expired flag is sticky). Lock-loser returns a pending status with the stale token withheld.
- **Valkey lock** (`idenfy:recreate-lock:<id>`, `SET NX EX 30s`) held **only** around the iDenfy token API call — serializes concurrent pollers (host page + external tab poll independently). Plain status reads never take the lock.
- **`recreationCount` cap (10)** per `IdenfySession` row bounds iDenfy verification-credit cost/abuse (iDenfy bills per session).
- `APPROVED`/`DENIED`/`SUSPECTED` stay terminal (no auto-retry); only `EXPIRED` recovers.
- Shared by **gov-id and Clean Hands (AML)** flows via the same resolver — no flow-specific fork.

## Testing

`bun test src/services/idenfy-sessions/functions.test.ts` — 15 tests covering: cached & fresh-fetch EXPIRED recovery, cap (and overshoot self-heal), lock-miss pending (token withheld) + refreshed-row, iDenfy API error fallback, no-lock-on-plain-read, APPROVED/DENIED unchanged, and Clean Hands parity + cross-flow independence. (Pre-existing `credentials/utils.test.ts` env failure is unrelated.)

## Post-Deploy Monitoring & Validation

- **Logs (service `idenfy-sessions`):** watch for `Recreated expired iDenfy session` (healthy recovery), `iDenfy recreate cap reached` (users hitting the 10 cap — investigate if frequent), `iDenfy session re-creation failed` (iDenfy `/api/v2/token` errors).
- **Healthy signal:** gov-id/clean-hands "Completed redemption" volume holds or rises; fewer manual support session-resets for iDenfy expiry.
- **Failure signal / rollback trigger:** spike in `re-creation failed`, or duplicate-mint anomalies (recreationCount climbing unexpectedly). Rollback = revert this PR; behavior returns to the prior (looping) state, no data migration needed (`recreationCount` is an additive optional field).
- **Window/owner:** watch the first 24–48h after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)