### PR TITLE
fix(security): accept holoUserId via X-Holo-User-Id header (Phase 1, additive)

### DIFF
--- a/src/services/aml-sessions/endpoints.ts
+++ b/src/services/aml-sessions/endpoints.ts
@@ -14,6 +14,7 @@ import {
   getRouteHandlerConfig
 } from "../../init.js";
 import { SandboxVsLiveKYCRouteHandlerConfig, IOnfidoSession, ISandboxOnfidoSession } from "../../types.js";
+import { resolveHoloUserId } from "../../utils/holo-user-id.js";
 import { 
   getAccessToken as getPayPalAccessToken,
   capturePayPalOrder,
@@ -3378,7 +3379,7 @@ async function confirmStatementSandbox(req: Request, res: Response) {
 function createGetSessionsRouteHandler(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
     try {
-      const sigDigest = req.query.sigDigest;
+      const sigDigest = resolveHoloUserId(req, req.query.sigDigest);
       const id = req.query.id;
 
       if (!sigDigest && !id) {

--- a/src/services/biometrics-sessions/allow-sybils/endpoints.js
+++ b/src/services/biometrics-sessions/allow-sybils/endpoints.js
@@ -5,6 +5,7 @@ import {
   sessionStatusEnum,
 } from "../../../constants/misc.js";
 import { pinoOptions, logger } from "../../../utils/logger.js";
+import { resolveHoloUserId } from "../../../utils/holo-user-id.js";
 import { v4 as uuidV4 } from "uuid";
 
 const postSessionsLogger = logger.child({
@@ -101,7 +102,7 @@ async function postSessionV2(req, res) {
  */
 async function getSessions(req, res) {
   try {
-    const sigDigest = req.query.sigDigest;
+    const sigDigest = resolveHoloUserId(req, req.query.sigDigest);
     const id = req.query.id;
 
     if (!sigDigest && !id) {

--- a/src/services/biometrics-sessions/endpoints.js
+++ b/src/services/biometrics-sessions/endpoints.js
@@ -10,6 +10,7 @@ import {
 import { pinoOptions, logger } from "../../utils/logger.js";
 import { v4 as uuidV4 } from "uuid";
 import { rateLimitByTier } from "../../utils/rate-limiting.js";
+import { resolveHoloUserId } from "../../utils/holo-user-id.js";
 import { getRateLimitTier } from "../../utils/whitelist.js";
 import { isAlreadyRegisteredFailure } from "../../utils/errors.js";
 import {
@@ -140,7 +141,7 @@ async function postSessionV2(req, res) {
  */
 async function getSessions(req, res) {
   try {
-    const sigDigest = req.query.sigDigest;
+    const sigDigest = resolveHoloUserId(req, req.query.sigDigest);
     const id = req.query.id;
 
     if (!sigDigest && !id) {

--- a/src/services/credentials-v2.ts
+++ b/src/services/credentials-v2.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import { Model } from "mongoose";
 import { UserCredentialsV2, getRouteHandlerConfig } from "../init.js";
 import logger from "../utils/logger.js";
+import { resolveHoloUserId } from "../utils/holo-user-id.js";
 import {
   ISandboxUserCredentialsV2,
   IUserCredentialsV2,
@@ -208,7 +209,7 @@ async function storeOrUpdateBiometricsAllowSybilsCredentials(
  */
 function createGetCredentials(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
-    const holoUserId = req?.query?.holoUserId;
+    const holoUserId = resolveHoloUserId(req, req?.query?.holoUserId);
 
     if (!holoUserId) {
       getEndpointLogger.error("No holoUserId specified.");

--- a/src/services/credentials.ts
+++ b/src/services/credentials.ts
@@ -5,6 +5,7 @@ const { ethers } = ethersPkg;
 // import { poseidon } from "circomlibjs-old";
 import { mongoose, UserCredentials, zokProvider } from "../init.js";
 import logger from "../utils/logger.js";
+import { resolveHoloUserId } from "../utils/holo-user-id.js";
 import contractAddresses from "../constants/contractAddresses.js";
 import { holonymIssuers } from "../constants/misc.js";
 
@@ -98,7 +99,7 @@ async function storeOrUpdateUserCredentials(
  * Get user's encrypted credentials and symmetric key from document store.
  */
 async function getCredentials(req: Request, res: Response) {
-  const sigDigest = req?.query?.sigDigest;
+  const sigDigest = resolveHoloUserId(req, req?.query?.sigDigest);
 
   if (!sigDigest) {
     getEndpointLogger.error("No sigDigest specified.");

--- a/src/services/idenfy-sessions/endpoints.ts
+++ b/src/services/idenfy-sessions/endpoints.ts
@@ -6,6 +6,7 @@ import {
   getIdenfySessionById,
   getIdenfyStatusForSession,
 } from "./functions.js";
+import { resolveHoloUserId } from "../../utils/holo-user-id.js";
 
 const endpointLogger = logger.child({
   msgPrefix: "[/idenfy-sessions] ",
@@ -54,7 +55,7 @@ function getStatusHandler(config: SandboxVsLiveKYCRouteHandlerConfig) {
 function findBySignDigestHandler(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
     try {
-      const { sigDigest } = req.query;
+      const sigDigest = resolveHoloUserId(req, req.query.sigDigest);
 
       if (!sigDigest || typeof sigDigest !== "string") {
         return res

--- a/src/services/nullifiers.ts
+++ b/src/services/nullifiers.ts
@@ -3,6 +3,7 @@ import { HydratedDocument } from "mongoose";
 import { IEncryptedNullifiers, ISandboxEncryptedNullifiers, SandboxVsLiveKYCRouteHandlerConfig } from "../types.js";
 import { getRouteHandlerConfig } from "../init.js";
 import logger from "../utils/logger.js";
+import { resolveHoloUserId } from "../utils/holo-user-id.js";
 
 const getEndpointLogger = logger.child({ msgPrefix: "[GET /nullifiers] " });
 
@@ -36,7 +37,7 @@ async function validatePutNullifierArgs(
  */
 function createGetNullifiersRouteHandler(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
-    const holoUserId = req?.query?.holoUserId;
+    const holoUserId = resolveHoloUserId(req, req?.query?.holoUserId);
 
     if (!holoUserId) {
       getEndpointLogger.error("No holoUserId specified.");

--- a/src/services/onfido-sessions/endpoints.ts
+++ b/src/services/onfido-sessions/endpoints.ts
@@ -11,6 +11,7 @@ import {
   getOnfidoCheckAsync,
 } from "./functions.js";
 import { onfidoSDKTokenAndApplicantRateLimiter } from "../../utils/rate-limiting.js";
+import { resolveHoloUserId } from "../../utils/holo-user-id.js";
 
 const endpointLogger = logger.child({
   msgPrefix: "[Onfido Sessions Endpoints] ",
@@ -200,7 +201,7 @@ function getStatusHandler(config: SandboxVsLiveKYCRouteHandlerConfig) {
 function findBySignDigestHandler(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
     try {
-      const { sigDigest } = req.query;
+      const sigDigest = resolveHoloUserId(req, req.query.sigDigest);
 
       if (!sigDigest || typeof sigDigest !== "string") {
         return res.status(400).json({ error: "sigDigest query parameter is required" });

--- a/src/services/payment-secrets.ts
+++ b/src/services/payment-secrets.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import { Model, Types } from "mongoose";
 import { getRouteHandlerConfig } from "../init.js";
 import logger from "../utils/logger.js";
+import { resolveHoloUserId } from "../utils/holo-user-id.js";
 import {
   ISandboxPaymentSecret,
   IPaymentSecret,
@@ -139,7 +140,7 @@ async function storeOrUpdatePaymentSecret(
  */
 function createGetPaymentSecrets(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
-    const holoUserId = req?.query?.holoUserId;
+    const holoUserId = resolveHoloUserId(req, req?.query?.holoUserId);
     const checkRedemptionParam = req?.query?.checkRedemption;
     const checkRedemption = checkRedemptionParam === "true" || String(checkRedemptionParam) === "true";
 

--- a/src/services/phone/sessions/endpoints.ts
+++ b/src/services/phone/sessions/endpoints.ts
@@ -24,6 +24,7 @@ import {
   setSandboxPhoneSessionRefunded
 } from '../_utils/dynamodb.js'
 import { valkeyClient } from '../../../utils/valkey-glide.js'
+import { resolveHoloUserId } from '../../../utils/holo-user-id.js'
 import {
   sessionStatusEnum,
   supportedChainIds,
@@ -1288,7 +1289,7 @@ function createGetSessions(config: GetSessionsConfig) {
     res: Response
   ): Promise<Response> {
     try {
-      const sigDigest = req.query.sigDigest as string
+      const sigDigest = resolveHoloUserId(req, req.query.sigDigest) as string
       const id = req.query.id as string
 
       if (!sigDigest && !id) {

--- a/src/services/proof-metadata.ts
+++ b/src/services/proof-metadata.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import { mongoose, UserCredentials, UserProofMetadata } from "../init.js";
 import logger from "../utils/logger.js";
+import { resolveHoloUserId } from "../utils/holo-user-id.js";
 
 const postEndpointLogger = logger.child({ msgPrefix: "[POST /proof-metadata] " });
 const getEndpointLogger = logger.child({ msgPrefix: "[GET /proof-metadata] " });
@@ -9,7 +10,7 @@ const getEndpointLogger = logger.child({ msgPrefix: "[GET /proof-metadata] " });
  * Get user's encrypted proof metadata and symmetric key from document store.
  */
 async function getProofMetadata(req: Request, res: Response) {
-  const sigDigest = req?.query?.sigDigest;
+  const sigDigest = resolveHoloUserId(req, req?.query?.sigDigest);
 
   if (!sigDigest) {
     getEndpointLogger.error("No sigDigest specified.");

--- a/src/services/session-status.ts
+++ b/src/services/session-status.ts
@@ -12,6 +12,7 @@ import { getVeriffSessionDecision } from "../utils/veriff.js";
 // is kept for backward compat but its idenfy branch is now a stub.
 import { getOnfidoReports } from "../utils/onfido.js";
 import { getSumsubApplicantData } from "../utils/sumsub.js";
+import { resolveHoloUserId } from "../utils/holo-user-id.js";
 import { IIdvSessions, ISandboxSession, ISession, SandboxVsLiveKYCRouteHandlerConfig } from "../types.js";
 import { getOnfidoCheckAsync } from "./onfido/get-check-async.js";
 import { getOnfidoCheckAsync as getOnfidoCheckAsyncFromService, getOnfidoSessionById } from "./onfido-sessions/functions.js";
@@ -189,7 +190,7 @@ async function getOnfidoSessionStatus(
 function createGetSessionStatus(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
     try {
-      const sigDigest = req.query.sigDigest;
+      const sigDigest = resolveHoloUserId(req, req.query.sigDigest);
       const provider = req.query.provider; // not required
 
       if (!sigDigest) {

--- a/src/services/sessions/endpoints.ts
+++ b/src/services/sessions/endpoints.ts
@@ -14,6 +14,7 @@ import {
 } from "../../utils/paypal.js";
 import { createOnfidoSdkToken, createOnfidoCheck, createOnfidoWorkflowRun } from "../../utils/onfido.js";
 import { getSumsubAccessToken } from "../../utils/sumsub.js";
+import { resolveHoloUserId } from "../../utils/holo-user-id.js";
 import { SUMSUB_LEVEL_NAME } from "../../constants/sumsub.js";
 import {
   validateTxForSessionCreation,
@@ -1415,7 +1416,7 @@ async function refundV2(req: Request, res: Response) {
 function createGetSessionsRouteHandler(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
     try {
-      const sigDigest = req.query.sigDigest;
+      const sigDigest = resolveHoloUserId(req, req.query.sigDigest);
       const id = req.query.id;
       const last5days = req.query.last5days === "true" || false;
 

--- a/src/services/zk-passport/sessions.ts
+++ b/src/services/zk-passport/sessions.ts
@@ -15,6 +15,7 @@ import { rateLimitByTier } from "../../utils/rate-limiting.js";
 import { getRateLimitTier } from "../../utils/whitelist.js";
 import { pinoOptions, logger } from "../../utils/logger.js";
 import { makeUnknownErrorLoggable } from "../../utils/errors.js";
+import { resolveHoloUserId } from "../../utils/holo-user-id.js";
 import { getRouteHandlerConfig } from "../../init.js";
 import type { SandboxVsLiveKYCRouteHandlerConfig } from "../../types.js";
 
@@ -183,7 +184,7 @@ export async function postZkPassportSessionSandbox(req: Request, res: Response) 
 function createListZkPassportSessionsHandler(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
     try {
-      const sigDigest = req.query?.sigDigest;
+      const sigDigest = resolveHoloUserId(req, req.query?.sigDigest);
       if (!sigDigest || typeof sigDigest !== "string") {
         return res.status(400).json({ error: "sigDigest is required" });
       }
@@ -247,7 +248,7 @@ function createGetZkPassportSessionHandler(config: SandboxVsLiveKYCRouteHandlerC
       const session = await config.ZkPassportSessionModel.findOne({ _id: objectId }).exec();
       if (!session) return res.status(404).json({ error: "Session not found" });
 
-      const holoUserId = req.query?.holoUserId;
+      const holoUserId = resolveHoloUserId(req, req.query?.holoUserId);
       if (
         typeof holoUserId === "string" &&
         holoUserId &&

--- a/src/utils/holo-user-id.test.ts
+++ b/src/utils/holo-user-id.test.ts
@@ -44,6 +44,12 @@ describe("resolveHoloUserId", () => {
     expect(resolveHoloUserId(req, undefined)).toBeUndefined();
   });
 
+  it("treats a duplicated (comma-joined) header as absent and falls back", () => {
+    // Express joins repeated headers with ", "; a real holoUserId never has a comma.
+    const req = makeReq({ [HOLO_USER_ID_HEADER]: "aaa, bbb" });
+    expect(resolveHoloUserId(req, "xyz")).toBe("xyz");
+  });
+
   it("is case-insensitive on the header name", () => {
     const req = makeReq({ "x-holo-user-id": "abc" });
     expect(resolveHoloUserId(req, "xyz")).toBe("abc");

--- a/src/utils/holo-user-id.test.ts
+++ b/src/utils/holo-user-id.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "bun:test";
+import type { Request } from "express";
+import { resolveHoloUserId, HOLO_USER_ID_HEADER } from "./holo-user-id.js";
+
+/** Minimal Express-request stub exposing a case-insensitive `.header()`. */
+function makeReq(headers: Record<string, string> = {}): Request {
+  const lower: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) lower[k.toLowerCase()] = v;
+  return {
+    header(name: string) {
+      return lower[name.toLowerCase()];
+    },
+  } as unknown as Request;
+}
+
+describe("resolveHoloUserId", () => {
+  it("returns the header value when present, ignoring the fallback", () => {
+    const req = makeReq({ [HOLO_USER_ID_HEADER]: "abc" });
+    expect(resolveHoloUserId(req, "xyz")).toBe("abc");
+  });
+
+  it("returns the fallback when the header is absent", () => {
+    const req = makeReq();
+    expect(resolveHoloUserId(req, "xyz")).toBe("xyz");
+  });
+
+  it("treats an empty-string header as absent and falls back", () => {
+    const req = makeReq({ [HOLO_USER_ID_HEADER]: "" });
+    expect(resolveHoloUserId(req, "xyz")).toBe("xyz");
+  });
+
+  it("treats a whitespace-only header as absent and falls back", () => {
+    const req = makeReq({ [HOLO_USER_ID_HEADER]: "   " });
+    expect(resolveHoloUserId(req, "xyz")).toBe("xyz");
+  });
+
+  it("returns the header value even when the fallback is undefined", () => {
+    const req = makeReq({ [HOLO_USER_ID_HEADER]: "abc" });
+    expect(resolveHoloUserId(req, undefined)).toBe("abc");
+  });
+
+  it("returns the (undefined) fallback when neither header nor query value exists", () => {
+    const req = makeReq();
+    expect(resolveHoloUserId(req, undefined)).toBeUndefined();
+  });
+
+  it("is case-insensitive on the header name", () => {
+    const req = makeReq({ "x-holo-user-id": "abc" });
+    expect(resolveHoloUserId(req, "xyz")).toBe("abc");
+  });
+
+  it("does not trim the returned value (preserves downstream length checks)", () => {
+    const padded = " abc ";
+    const req = makeReq({ [HOLO_USER_ID_HEADER]: padded });
+    expect(resolveHoloUserId(req, "xyz")).toBe(padded);
+  });
+});

--- a/src/utils/holo-user-id.ts
+++ b/src/utils/holo-user-id.ts
@@ -5,6 +5,12 @@ import type { Request } from "express";
  * holoUserId / sigDigest. Moving this value out of URL query strings keeps it
  * out of browser history, proxy/CDN access logs, and monitoring pipelines
  * (see internal-docs #1505).
+ *
+ * NOTE: this literal is duplicated in the frontend at
+ * frontend/src/lib/frontend/holoUserIdHeader.ts (the two repos deploy
+ * independently and share no package). They MUST stay in sync — a silent
+ * divergence would break resolution once the Phase 2/3 query fallback is
+ * removed. Keep both in step when changing the header name.
  */
 export const HOLO_USER_ID_HEADER = "X-Holo-User-Id";
 
@@ -22,13 +28,23 @@ export const HOLO_USER_ID_HEADER = "X-Holo-User-Id";
  * The header value is returned as-is (untrimmed) so downstream validation
  * (length/type checks) and authorization comparisons against
  * `session.sigDigest` behave identically to the query-sourced value.
+ *
+ * A duplicated header is ignored: Express joins repeated header values with
+ * ", ", and a legitimate holoUserId (64 hex chars) never contains a comma, so
+ * a comma-bearing value is treated as absent and we fall back to the query
+ * param. This mirrors how the query path rejects a duplicated `?sigDigest=a&b`
+ * (an array) rather than trusting an ambiguous value.
  */
 export function resolveHoloUserId<T>(
   req: Request,
   fallback: T
 ): string | T {
   const headerValue = req.header(HOLO_USER_ID_HEADER);
-  if (typeof headerValue === "string" && headerValue.trim().length > 0) {
+  if (
+    typeof headerValue === "string" &&
+    headerValue.trim().length > 0 &&
+    !headerValue.includes(",")
+  ) {
     return headerValue;
   }
   return fallback;

--- a/src/utils/holo-user-id.ts
+++ b/src/utils/holo-user-id.ts
@@ -1,0 +1,35 @@
+import type { Request } from "express";
+
+/**
+ * The request header through which the frontend transmits the user's
+ * holoUserId / sigDigest. Moving this value out of URL query strings keeps it
+ * out of browser history, proxy/CDN access logs, and monitoring pipelines
+ * (see internal-docs #1505).
+ */
+export const HOLO_USER_ID_HEADER = "X-Holo-User-Id";
+
+/**
+ * Resolve the caller's holoUserId / sigDigest, preferring the
+ * `X-Holo-User-Id` request header and falling back to the value the handler
+ * previously read from the query string.
+ *
+ * Phase 1 of the rollout is intentionally additive: the header takes
+ * precedence when present, but requests that still send only the query param
+ * continue to work unchanged. A present-but-empty (or whitespace-only) header
+ * is treated as absent so a client cannot lock itself out by sending an empty
+ * value.
+ *
+ * The header value is returned as-is (untrimmed) so downstream validation
+ * (length/type checks) and authorization comparisons against
+ * `session.sigDigest` behave identically to the query-sourced value.
+ */
+export function resolveHoloUserId<T>(
+  req: Request,
+  fallback: T
+): string | T {
+  const headerValue = req.header(HOLO_USER_ID_HEADER);
+  if (typeof headerValue === "string" && headerValue.trim().length > 0) {
+    return headerValue;
+  }
+  return fallback;
+}


### PR DESCRIPTION
## Summary

Phase 1 of moving the user's `sigDigest`/`holoUserId` identifier — the sole authorization factor for reading a user's identity records — out of URL query strings and into an `X-Holo-User-Id` request header. Query strings leak into browser history, proxy/CDN access logs, and monitoring pipelines (OWASP; bug-bounty report internal-docs #1505).

This change is **strictly additive and backwards-compatible**: server GET handlers now read the value via a new `resolveHoloUserId(req, fallback)` helper that prefers the header and falls back to the existing query param when the header is absent. Query-only clients keep working; header and query rollouts can deploy in any order.

## What changed

- **New helper** `src/utils/holo-user-id.ts` — `resolveHoloUserId(req, fallback)`: header-preferred, treats empty/whitespace and duplicated (comma-joined) headers as absent, returns the value untrimmed so downstream length/type validation and `session.sigDigest` comparisons are unchanged.
- Applied to **all 15** GET handlers that read `sigDigest`/`holoUserId` from `req.query`: credentials v1/v2, proof-metadata, sessions, session-status, aml-sessions, nullifiers, payment-secrets, onfido-sessions, idenfy-sessions, zk-passport sessions (list + `:sid`), phone sessions, biometrics-sessions + allow-sybils.
- Unit tests for the helper (9 cases); `tsc --noEmit` clean.

The matching frontend change (sends the header, still sends the query param) is in a companion human-id PR that bumps this submodule.

## Deferred to later phases (NOT in this PR)
- **Phase 2** — frontend stops sending the value in query strings.
- **Phase 3** — this server drops the query fallback (header becomes required).

## Known residuals to address before Phase 2
- **CDN cache poisoning:** once the query param is dropped, caches keying on URL alone could serve users each other's records. Phase 2 must emit `Vary: X-Holo-User-Id` or exclude these GETs from caching. (Phase 1 is safe — URLs still differ per user.)
- **Header redaction:** add `X-Holo-User-Id` to Datadog APM / reverse-proxy header-redaction lists, else the secret just moves from URL logs to header logs.
- **Removal ordering:** Phase 3 must be gated on logs showing zero query-form traffic (incl. non-frontend callers of `/idenfy-sessions`, legacy `/credentials`, `/session-status` v1).

## Post-Deploy Monitoring & Validation
- **Watch:** 4xx rates on the affected GET routes (credentials/v2, sessions, aml-sessions, nullifiers, payment-secrets, etc.) — should be flat, since behavior is unchanged for query-only clients.
- **Healthy signal:** requests succeed whether they carry the header, the query param, or both.
- **Failure signal / rollback trigger:** a spike in 400 "missing sigDigest/holoUserId" or 401 on these routes → revert this branch (additive change, safe to revert).
- **Verify:** confirm a real cross-origin request with the `X-Holo-User-Id` header passes CORS preflight in staging before Phase 2.

## Test plan
- `bun test src/utils/holo-user-id.test.ts` — 9 pass
- `bunx tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)