### PR TITLE
feat(security): Phase 3 — drop query fallback, X-Holo-User-Id header only

### DIFF
--- a/src/services/aml-sessions/endpoints.ts
+++ b/src/services/aml-sessions/endpoints.ts
@@ -3379,7 +3379,7 @@ async function confirmStatementSandbox(req: Request, res: Response) {
 function createGetSessionsRouteHandler(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
     try {
-      const sigDigest = resolveHoloUserId(req, req.query.sigDigest);
+      const sigDigest = resolveHoloUserId(req);
       const id = req.query.id;
 
       if (!sigDigest && !id) {

--- a/src/services/biometrics-sessions/allow-sybils/endpoints.js
+++ b/src/services/biometrics-sessions/allow-sybils/endpoints.js
@@ -102,7 +102,7 @@ async function postSessionV2(req, res) {
  */
 async function getSessions(req, res) {
   try {
-    const sigDigest = resolveHoloUserId(req, req.query.sigDigest);
+    const sigDigest = resolveHoloUserId(req);
     const id = req.query.id;
 
     if (!sigDigest && !id) {

--- a/src/services/biometrics-sessions/endpoints.js
+++ b/src/services/biometrics-sessions/endpoints.js
@@ -141,7 +141,7 @@ async function postSessionV2(req, res) {
  */
 async function getSessions(req, res) {
   try {
-    const sigDigest = resolveHoloUserId(req, req.query.sigDigest);
+    const sigDigest = resolveHoloUserId(req);
     const id = req.query.id;
 
     if (!sigDigest && !id) {

--- a/src/services/credentials-v2.ts
+++ b/src/services/credentials-v2.ts
@@ -209,7 +209,7 @@ async function storeOrUpdateBiometricsAllowSybilsCredentials(
  */
 function createGetCredentials(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
-    const holoUserId = resolveHoloUserId(req, req?.query?.holoUserId);
+    const holoUserId = resolveHoloUserId(req);
 
     if (!holoUserId) {
       getEndpointLogger.error("No holoUserId specified.");

--- a/src/services/credentials.ts
+++ b/src/services/credentials.ts
@@ -99,7 +99,7 @@ async function storeOrUpdateUserCredentials(
  * Get user's encrypted credentials and symmetric key from document store.
  */
 async function getCredentials(req: Request, res: Response) {
-  const sigDigest = resolveHoloUserId(req, req?.query?.sigDigest);
+  const sigDigest = resolveHoloUserId(req);
 
   if (!sigDigest) {
     getEndpointLogger.error("No sigDigest specified.");

--- a/src/services/idenfy-sessions/endpoints.ts
+++ b/src/services/idenfy-sessions/endpoints.ts
@@ -55,7 +55,7 @@ function getStatusHandler(config: SandboxVsLiveKYCRouteHandlerConfig) {
 function findBySignDigestHandler(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
     try {
-      const sigDigest = resolveHoloUserId(req, req.query.sigDigest);
+      const sigDigest = resolveHoloUserId(req);
 
       if (!sigDigest || typeof sigDigest !== "string") {
         return res

--- a/src/services/nullifiers.ts
+++ b/src/services/nullifiers.ts
@@ -37,7 +37,7 @@ async function validatePutNullifierArgs(
  */
 function createGetNullifiersRouteHandler(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
-    const holoUserId = resolveHoloUserId(req, req?.query?.holoUserId);
+    const holoUserId = resolveHoloUserId(req);
 
     if (!holoUserId) {
       getEndpointLogger.error("No holoUserId specified.");

--- a/src/services/onfido-sessions/endpoints.ts
+++ b/src/services/onfido-sessions/endpoints.ts
@@ -201,7 +201,7 @@ function getStatusHandler(config: SandboxVsLiveKYCRouteHandlerConfig) {
 function findBySignDigestHandler(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
     try {
-      const sigDigest = resolveHoloUserId(req, req.query.sigDigest);
+      const sigDigest = resolveHoloUserId(req);
 
       if (!sigDigest || typeof sigDigest !== "string") {
         return res.status(400).json({ error: "sigDigest query parameter is required" });

--- a/src/services/payment-secrets.ts
+++ b/src/services/payment-secrets.ts
@@ -140,7 +140,7 @@ async function storeOrUpdatePaymentSecret(
  */
 function createGetPaymentSecrets(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
-    const holoUserId = resolveHoloUserId(req, req?.query?.holoUserId);
+    const holoUserId = resolveHoloUserId(req);
     const checkRedemptionParam = req?.query?.checkRedemption;
     const checkRedemption = checkRedemptionParam === "true" || String(checkRedemptionParam) === "true";
 

--- a/src/services/phone/sessions/endpoints.ts
+++ b/src/services/phone/sessions/endpoints.ts
@@ -1289,7 +1289,7 @@ function createGetSessions(config: GetSessionsConfig) {
     res: Response
   ): Promise<Response> {
     try {
-      const sigDigest = resolveHoloUserId(req, req.query.sigDigest) as string
+      const sigDigest = resolveHoloUserId(req) as string
       const id = req.query.id as string
 
       if (!sigDigest && !id) {

--- a/src/services/proof-metadata.ts
+++ b/src/services/proof-metadata.ts
@@ -10,7 +10,7 @@ const getEndpointLogger = logger.child({ msgPrefix: "[GET /proof-metadata] " });
  * Get user's encrypted proof metadata and symmetric key from document store.
  */
 async function getProofMetadata(req: Request, res: Response) {
-  const sigDigest = resolveHoloUserId(req, req?.query?.sigDigest);
+  const sigDigest = resolveHoloUserId(req);
 
   if (!sigDigest) {
     getEndpointLogger.error("No sigDigest specified.");

--- a/src/services/session-status.ts
+++ b/src/services/session-status.ts
@@ -190,7 +190,7 @@ async function getOnfidoSessionStatus(
 function createGetSessionStatus(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
     try {
-      const sigDigest = resolveHoloUserId(req, req.query.sigDigest);
+      const sigDigest = resolveHoloUserId(req);
       const provider = req.query.provider; // not required
 
       if (!sigDigest) {

--- a/src/services/sessions/endpoints.ts
+++ b/src/services/sessions/endpoints.ts
@@ -1416,7 +1416,7 @@ async function refundV2(req: Request, res: Response) {
 function createGetSessionsRouteHandler(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
     try {
-      const sigDigest = resolveHoloUserId(req, req.query.sigDigest);
+      const sigDigest = resolveHoloUserId(req);
       const id = req.query.id;
       const last5days = req.query.last5days === "true" || false;
 

--- a/src/services/zk-passport/sessions.ts
+++ b/src/services/zk-passport/sessions.ts
@@ -184,7 +184,7 @@ export async function postZkPassportSessionSandbox(req: Request, res: Response) 
 function createListZkPassportSessionsHandler(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
     try {
-      const sigDigest = resolveHoloUserId(req, req.query?.sigDigest);
+      const sigDigest = resolveHoloUserId(req);
       if (!sigDigest || typeof sigDigest !== "string") {
         return res.status(400).json({ error: "sigDigest is required" });
       }
@@ -248,7 +248,7 @@ function createGetZkPassportSessionHandler(config: SandboxVsLiveKYCRouteHandlerC
       const session = await config.ZkPassportSessionModel.findOne({ _id: objectId }).exec();
       if (!session) return res.status(404).json({ error: "Session not found" });
 
-      const holoUserId = resolveHoloUserId(req, req.query?.holoUserId);
+      const holoUserId = resolveHoloUserId(req);
       if (
         typeof holoUserId === "string" &&
         holoUserId &&

--- a/src/utils/holo-user-id.test.ts
+++ b/src/utils/holo-user-id.test.ts
@@ -14,50 +14,40 @@ function makeReq(headers: Record<string, string> = {}): Request {
 }
 
 describe("resolveHoloUserId", () => {
-  it("returns the header value when present, ignoring the fallback", () => {
+  it("returns the header value when present", () => {
     const req = makeReq({ [HOLO_USER_ID_HEADER]: "abc" });
-    expect(resolveHoloUserId(req, "xyz")).toBe("abc");
+    expect(resolveHoloUserId(req)).toBe("abc");
   });
 
-  it("returns the fallback when the header is absent", () => {
+  it("returns undefined when the header is absent (no query fallback in Phase 3)", () => {
     const req = makeReq();
-    expect(resolveHoloUserId(req, "xyz")).toBe("xyz");
+    expect(resolveHoloUserId(req)).toBeUndefined();
   });
 
-  it("treats an empty-string header as absent and falls back", () => {
+  it("returns undefined for an empty-string header", () => {
     const req = makeReq({ [HOLO_USER_ID_HEADER]: "" });
-    expect(resolveHoloUserId(req, "xyz")).toBe("xyz");
+    expect(resolveHoloUserId(req)).toBeUndefined();
   });
 
-  it("treats a whitespace-only header as absent and falls back", () => {
+  it("returns undefined for a whitespace-only header", () => {
     const req = makeReq({ [HOLO_USER_ID_HEADER]: "   " });
-    expect(resolveHoloUserId(req, "xyz")).toBe("xyz");
+    expect(resolveHoloUserId(req)).toBeUndefined();
   });
 
-  it("returns the header value even when the fallback is undefined", () => {
-    const req = makeReq({ [HOLO_USER_ID_HEADER]: "abc" });
-    expect(resolveHoloUserId(req, undefined)).toBe("abc");
-  });
-
-  it("returns the (undefined) fallback when neither header nor query value exists", () => {
-    const req = makeReq();
-    expect(resolveHoloUserId(req, undefined)).toBeUndefined();
-  });
-
-  it("treats a duplicated (comma-joined) header as absent and falls back", () => {
+  it("returns undefined for a duplicated (comma-joined) header", () => {
     // Express joins repeated headers with ", "; a real holoUserId never has a comma.
     const req = makeReq({ [HOLO_USER_ID_HEADER]: "aaa, bbb" });
-    expect(resolveHoloUserId(req, "xyz")).toBe("xyz");
+    expect(resolveHoloUserId(req)).toBeUndefined();
   });
 
   it("is case-insensitive on the header name", () => {
     const req = makeReq({ "x-holo-user-id": "abc" });
-    expect(resolveHoloUserId(req, "xyz")).toBe("abc");
+    expect(resolveHoloUserId(req)).toBe("abc");
   });
 
   it("does not trim the returned value (preserves downstream length checks)", () => {
     const padded = " abc ";
     const req = makeReq({ [HOLO_USER_ID_HEADER]: padded });
-    expect(resolveHoloUserId(req, "xyz")).toBe(padded);
+    expect(resolveHoloUserId(req)).toBe(padded);
   });
 });

--- a/src/utils/holo-user-id.ts
+++ b/src/utils/holo-user-id.ts
@@ -9,36 +9,27 @@ import type { Request } from "express";
  * NOTE: this literal is duplicated in the frontend at
  * frontend/src/lib/frontend/holoUserIdHeader.ts (the two repos deploy
  * independently and share no package). They MUST stay in sync — a silent
- * divergence would break resolution once the Phase 2/3 query fallback is
- * removed. Keep both in step when changing the header name.
+ * divergence would break resolution now that the query fallback is removed
+ * (Phase 3). Keep both in step when changing the header name.
  */
 export const HOLO_USER_ID_HEADER = "X-Holo-User-Id";
 
 /**
- * Resolve the caller's holoUserId / sigDigest, preferring the
- * `X-Holo-User-Id` request header and falling back to the value the handler
- * previously read from the query string.
+ * Resolve the caller's holoUserId / sigDigest from the `X-Holo-User-Id`
+ * request header.
  *
- * Phase 1 of the rollout is intentionally additive: the header takes
- * precedence when present, but requests that still send only the query param
- * continue to work unchanged. A present-but-empty (or whitespace-only) header
- * is treated as absent so a client cannot lock itself out by sending an empty
- * value.
+ * Phase 3 of the rollout: the header is now the only accepted source — the
+ * query-param fallback has been removed, so the identifier can never re-enter
+ * a URL. Returns `undefined` when the header is absent, empty/whitespace-only,
+ * or duplicated (Express joins repeated headers with ", ", and a legitimate
+ * holoUserId never contains a comma); callers treat `undefined` as a missing
+ * identifier and return their existing 400.
  *
  * The header value is returned as-is (untrimmed) so downstream validation
  * (length/type checks) and authorization comparisons against
- * `session.sigDigest` behave identically to the query-sourced value.
- *
- * A duplicated header is ignored: Express joins repeated header values with
- * ", ", and a legitimate holoUserId (64 hex chars) never contains a comma, so
- * a comma-bearing value is treated as absent and we fall back to the query
- * param. This mirrors how the query path rejects a duplicated `?sigDigest=a&b`
- * (an array) rather than trusting an ambiguous value.
+ * `session.sigDigest` are unchanged.
  */
-export function resolveHoloUserId<T>(
-  req: Request,
-  fallback: T
-): string | T {
+export function resolveHoloUserId(req: Request): string | undefined {
   const headerValue = req.header(HOLO_USER_ID_HEADER);
   if (
     typeof headerValue === "string" &&
@@ -47,5 +38,5 @@ export function resolveHoloUserId<T>(
   ) {
     return headerValue;
   }
-  return fallback;
+  return undefined;
 }


### PR DESCRIPTION
## Summary

**Phase 3** (final) of the identifier-transport migration. `resolveHoloUserId` now reads `sigDigest`/`holoUserId` **solely** from the `X-Holo-User-Id` header — the `req.query` fallback is removed at all 15 GET handlers. After this, the value can never re-enter a URL.

**Stacked on Phase 1** — base branch is `fix/sigdigest-to-header` (#55). The companion human-id PR bumps this submodule pointer.

## What changed
- `resolveHoloUserId(req)` — header-only; returns `undefined` when the header is absent, empty/whitespace-only, or duplicated (comma-joined). Signature simplified (no more `fallback` generic).
- All 15 call sites updated from `resolveHoloUserId(req, req.query.X)` → `resolveHoloUserId(req)`. Each handler's existing "missing identifier" 400 now fires on `undefined`.
- Unrelated query params (`id`, etc.) untouched. Helper tests updated to the header-only contract.
- `tsc --noEmit` clean; `bun test` helper suite passes (7).

Error-message strings (e.g. "sigDigest is required") were intentionally left unchanged to avoid breaking any client/test that matches on them.

## 🚨 Deploy gate (do NOT merge/deploy prematurely)
This is the one breaking step. It **must not deploy** until:
1. **Phase 2 is live** (frontend sends the identifier only in the header), and
2. **Logs confirm zero query-form traffic** on these routes — including **non-frontend / legacy callers**: `/idenfy-sessions` (findBySignDigest), legacy `GET /credentials` (v1), and `GET /session-status` v1.

Deploying while any client still sends only the query param will return 400 "missing identifier" for those requests (broken credential/session fetches).

## Post-Deploy Monitoring & Validation
- **Watch:** 400 "missing sigDigest/holoUserId" rates on the affected GETs — should stay ~0.
- **Failure signal / rollback:** any rise in those 400s means a query-only client still exists → revert this PR (restores the fallback) and re-verify traffic before retrying.

## Test plan
- `bun test src/utils/holo-user-id.test.ts` — 7 pass
- `bunx tsc --noEmit` — clean

Plan: `docs/plans/2026-07-01-001-fix-move-sigdigest-to-header-plan.md` (U7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)