### PR TITLE
fix(idenfy): mark parent session VERIFICATION_FAILED on DENIED

### DIFF
--- a/src/services/idenfy/webhooks.ts
+++ b/src/services/idenfy/webhooks.ts
@@ -3,6 +3,7 @@ import { getRouteHandlerConfig } from "../../init.js";
 import { SandboxVsLiveKYCRouteHandlerConfig } from "../../types.js";
 import { sessionStatusEnum } from "../../constants/misc.js";
 import { pinoOptions, logger } from "../../utils/logger.js";
+import { failSession } from "../../utils/sessions.js";
 import { verifyIdenfyWebhookSignature } from "./webhook-signature.js";
 
 export { verifyIdenfyWebhookSignature };
@@ -215,6 +216,36 @@ function createHandleIdenfyWebhookRouteHandler(
           },
           "Updated iDenfy session from webhook"
         );
+      }
+
+      // Propagate a DENIED decision to the parent session so the user gets an
+      // automated refund path. This webhook is the earliest and most reliable
+      // signal of a denial. Without this the parent session stays IN_PROGRESS:
+      // the frontend's "verification failed (status is denied)" screen only
+      // polls GET /session-status/v2 (historically a read-only endpoint) and
+      // never reaches the credentials endpoint that otherwise calls
+      // failSession(), leaving a dead-end state with no refund option
+      // (issue #1120). A single standalone iDenfy session may be referenced by
+      // a gov-id Session or a Clean Hands AMLChecksSession, so fail whichever
+      // in-progress parent points at it. Guarded to IN_PROGRESS so we never
+      // clobber ISSUED/REFUNDED/already-failed or fail an unpaid
+      // (NEEDS_PAYMENT) session.
+      if (overall === "DENIED") {
+        const parentFilter = {
+          idenfySessionId: idenfySession._id,
+          status: sessionStatusEnum.IN_PROGRESS,
+        };
+        const [govIdParents, amlParents] = await Promise.all([
+          config.SessionModel.find(parentFilter).exec(),
+          config.AMLChecksSessionModel.find(parentFilter).exec(),
+        ]);
+        for (const parent of [...govIdParents, ...amlParents]) {
+          await failSession(parent as any, failureReason ?? "iDenfy verification denied");
+          webhookLogger.info(
+            { scanRef, parentSessionId: parent._id?.toString() },
+            "Failed parent session from iDenfy DENIED webhook"
+          );
+        }
       }
 
       return res.status(200).json({ received: true });

--- a/src/services/session-status.ts
+++ b/src/services/session-status.ts
@@ -13,6 +13,8 @@ import { getVeriffSessionDecision } from "../utils/veriff.js";
 import { getOnfidoReports } from "../utils/onfido.js";
 import { getSumsubApplicantData } from "../utils/sumsub.js";
 import { resolveHoloUserId } from "../utils/holo-user-id.js";
+import { failSession } from "../utils/sessions.js";
+import { sessionStatusEnum } from "../constants/misc.js";
 import { IIdvSessions, ISandboxSession, ISession, SandboxVsLiveKYCRouteHandlerConfig } from "../types.js";
 import { getOnfidoCheckAsync } from "./onfido/get-check-async.js";
 import { getOnfidoCheckAsync as getOnfidoCheckAsyncFromService, getOnfidoSessionById } from "./onfido-sessions/functions.js";
@@ -248,6 +250,19 @@ async function getSessionStatusSandbox(req: Request, res: Response) {
 
 /**
  * ENDPOINT
+ *
+ * GET /session-status/v2 — resolve the current IDV status for a session.
+ *
+ * NOTE: This is primarily a READ endpoint, but the iDenfy branch has an
+ * intentional WRITE side effect. When iDenfy has DENIED the verification, the
+ * parent session (gov-id `SessionModel` or Clean Hands `AMLChecksSessionModel`)
+ * is transitioned to `VERIFICATION_FAILED` here. This is required so denied
+ * users get a refund path: the frontend's "verification failed" screen polls
+ * only this endpoint and never hits the credentials endpoint that otherwise
+ * fails the session, so without this the parent session would stay IN_PROGRESS
+ * forever with no automated refund option (issue #1120). It complements the
+ * iDenfy webhook, covering the case where the webhook was not delivered. See
+ * the inline SIDE EFFECT comment in the idenfy branch below.
  */
 function createGetSessionStatusV2(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async function getSessionStatusV2(req: Request, res: Response) {
@@ -338,6 +353,27 @@ function createGetSessionStatusV2(config: SandboxVsLiveKYCRouteHandlerConfig) {
           config,
           idenfyDoc.toObject()
         );
+
+        // SIDE EFFECT (see the note on getSessionStatusV2 above). Although this
+        // endpoint is primarily a read, a resolved DENIED decision transitions
+        // the parent session to VERIFICATION_FAILED here. For a denied iDenfy
+        // verification the frontend polls only this endpoint (the denied screen
+        // never advances to the credentials endpoint, the other place that
+        // fails the session), so this is the sole reliable point at which the
+        // parent session — gov-id (SessionModel) or Clean Hands
+        // (AMLChecksSessionModel) — gets marked failed and the user becomes
+        // eligible for a refund (issue #1120). Guarded to IN_PROGRESS so we
+        // never overwrite ISSUED/REFUNDED/already-failed or fail an unpaid
+        // (NEEDS_PAYMENT) session.
+        if (
+          resolved?.idenfyVerificationStatus === "DENIED" &&
+          ambiguousSession.status === sessionStatusEnum.IN_PROGRESS
+        ) {
+          await failSession(
+            ambiguousSession,
+            resolved?.verificationFailureReason ?? "iDenfy verification denied"
+          );
+        }
 
         return res.status(200).json({
           idenfy: {


### PR DESCRIPTION
## Problem

Users who fail iDenfy verification (`status: DENIED`) were landing in a dead-end state with **no automated refund path** ([internal-docs#1120](https://github.com/holonym-foundation/internal-docs/issues/1120)). The refund endpoint requires the session to be `VERIFICATION_FAILED`, but denied iDenfy sessions never reached that state.

**Root cause:** The only code that flipped the parent session to `VERIFICATION_FAILED` on a DENIED decision lived in the credentials endpoints (`/idenfy/credentials/v3/...` for gov-id, `/aml-sessions/.../credentials/idenfy/v4/...` for Clean Hands). But the frontend never calls those on a denied verdict:

- The iDenfy webhook updated only the **standalone `IdenfySession`** collection (`status: 'failed'`) — it computed `VERIFICATION_FAILED` but discarded it, never touching the parent `Session`/`AMLChecksSession`.
- The frontend's "verification failed (status is denied)" screen polls only `GET /session-status/v2`, which read the standalone iDenfy status and returned — it also never touched the parent. The credentials endpoint (which would call `failSession`) is only reached on a `completed` verdict.

Net result: the parent gov-id `Session` / Clean Hands `AMLChecksSession` stayed `IN_PROGRESS` indefinitely, so the frontend's (correct) refund gate — which requires `VERIFICATION_FAILED` — never matched, and no refund banner appeared. This affects **both gov-id and Clean Hands** iDenfy flows.

## Fix

Fail the parent session on `DENIED` in the two places that actually observe the denial:

1. **iDenfy webhook** (`services/idenfy/webhooks.ts`) — the earliest and most reliable denial signal. Fails whichever in-progress parent (gov-id `Session` or Clean Hands `AMLChecksSession`) references the standalone iDenfy session.
2. **`/session-status/v2`** idenfy branch (`services/session-status.ts`) — covers the case where the webhook wasn't delivered. This endpoint was historically read-only, so the new write **side effect is clearly documented** on the route handler JSDoc and inline at the write site, per review request.

Both paths guard on `IN_PROGRESS`, so `ISSUED` / `REFUNDED` / already-failed and unpaid (`NEEDS_PAYMENT`) sessions are never clobbered. `DENIED` is a terminal iDenfy status, so there is no risk of overwriting a session that later becomes `APPROVED`.

## Scope notes

- Deliberately narrow to `DENIED` (per request). `SUSPECTED`/`EXPIRED` are left to existing handling (`EXPIRED` has separate recovery/recreate logic).
- Does **not** add a refund CTA to the failure screen or change iframe/SDK behavior — out of scope for this change. Those remain open discoverability items in #1120.

## Testing

- `tsc --noEmit` passes.
- Existing iDenfy webhook + idenfy-sessions tests pass. Handler-level webhook tests remain a pre-existing TODO (`webhooks.test.ts:50`) blocked on missing model-mock infra; not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)