### PR TITLE
fix(aml-sessions): use structured logger for pay/v4 unknown errors

### DIFF
--- a/src/services/aml-sessions/endpoints.ts
+++ b/src/services/aml-sessions/endpoints.ts
@@ -1041,9 +1041,9 @@ function createPayForSessionV4RouteHandler(config: SandboxVsLiveKYCRouteHandlerC
         return res.status(err.statusCode).json({ error: err.message });
       }
 
-      console.log(
-        "POST /aml-sessions/:_id/pay/v4: Error encountered",
-        makeUnknownErrorLoggable(err),
+      payForSessionV4Logger.error(
+        { error: makeUnknownErrorLoggable(err) },
+        "Error encountered",
       );
       return res.status(500).json({ error: "An unknown error occurred" });
     }


### PR DESCRIPTION
## Summary

- Replace `console.log` with `payForSessionV4Logger.error` in the `payCleanHandsSessionV4` catch block so non-`PaymentError` exceptions appear in Datadog structured logs instead of being invisible

## Context

`POST /aml-sessions/{id}/pay/v4` has been returning HTTP 500 `"An unknown error occurred"` for 50+ requests across 7 users (Jul 17–20). The actual error details were only written via `console.log`, which doesn't reach Datadog — making the root cause invisible. This fix ensures future errors are captured by the structured Pino logger.

The underlying upstream failure (Onfido API, RPC, Valkey, or MongoDB) still needs investigation once we can see the actual errors in Datadog.

Ref: holonym-foundation/internal-docs#1743

## Test plan

- [ ] Deploy to staging and trigger a payment flow — verify structured error logs appear in Datadog when a non-`PaymentError` is thrown
- [ ] Confirm no regression in normal pay/v4 success path

🤖 Generated with [Claude Code](https://claude.com/claude-code)