### PR TITLE
fix: update standalone Onfido session status

### DIFF
--- a/src/services/onfido/credentials/utils.ts
+++ b/src/services/onfido/credentials/utils.ts
@@ -1,7 +1,7 @@
 import ethersPkg from "ethers";
 const { ethers } = ethersPkg;
 import { poseidon } from "circomlibjs-old";
-import { Model } from "mongoose";
+import { HydratedDocument, Model } from "mongoose";
 import {
   Session,
   UserVerifications,
@@ -506,5 +506,25 @@ export async function updateSessionStatus(SessionModel: Model<ISession | ISandbo
     await metaSession.save();
   } catch (err) {
     console.log("onfido/credentials: Error updating session status", err);
+  }
+}
+
+/**
+ * Update a session that the caller has already resolved.
+ *
+ * Standalone Onfido sessions keep their check_id in IOnfidoSession rather than
+ * ISession, so looking up an ISession by check_id does not work for that flow.
+ */
+export async function updateResolvedSessionStatus(
+  metaSession: HydratedDocument<ISession | ISandboxSession>,
+  status: string,
+  failureReason?: string
+) {
+  try {
+    metaSession.status = status;
+    if (failureReason) metaSession.verificationFailureReason = failureReason;
+    await metaSession.save();
+  } catch (err) {
+    console.log("onfido/credentials: Error updating resolved session status", err);
   }
 }

--- a/src/services/onfido/credentials/v3.ts
+++ b/src/services/onfido/credentials/v3.ts
@@ -28,6 +28,7 @@ import {
   saveCollisionMetadata,
   saveUserToDb,
   getSession,
+  updateSessionStatus,
   updateResolvedSessionStatus,
 } from "./utils.js"
 import { ISession, OnfidoDocumentReport, OnfidoReport, SandboxVsLiveKYCRouteHandlerConfig } from "../../../types.js";
@@ -167,7 +168,39 @@ function createGetCredentialsV3(config: SandboxVsLiveKYCRouteHandlerConfig) {
 
         endpointLoggerV3.info({ uuidV2: uuidNew, check_id: checkIdFromNullifier }, "Issuing credentials");
 
-        await updateResolvedSessionStatus(session, sessionStatusEnum.ISSUED);
+        // The requested session can differ from the session that originally
+        // produced this nullifier. Mark the session that owns this check as
+        // issued, not the caller-selected session.
+        const onfidoSession = await config.OnfidoSessionModel.findOne({
+          check_id: checkIdFromNullifier,
+        }).exec();
+        if (onfidoSession) {
+          const issuingSession = await config.SessionModel.findById(
+            onfidoSession.createdBySessionId
+          ).exec();
+          if (issuingSession) {
+            await updateResolvedSessionStatus(
+              issuingSession,
+              sessionStatusEnum.ISSUED
+            );
+          } else {
+            endpointLoggerV3.error(
+              {
+                check_id: checkIdFromNullifier,
+                onfidoSessionId: onfidoSession._id,
+                createdBySessionId: onfidoSession.createdBySessionId,
+              },
+              "Unable to find parent session for standalone Onfido check"
+            );
+          }
+        } else {
+          // Legacy sessions store the check ID directly on ISession.
+          await updateSessionStatus(
+            config.SessionModel,
+            checkIdFromNullifier,
+            sessionStatusEnum.ISSUED
+          );
+        }
 
         return res.status(200).json(response);
       }

--- a/src/services/onfido/credentials/v3.ts
+++ b/src/services/onfido/credentials/v3.ts
@@ -28,7 +28,7 @@ import {
   saveCollisionMetadata,
   saveUserToDb,
   getSession,
-  updateSessionStatus,
+  updateResolvedSessionStatus,
 } from "./utils.js"
 import { ISession, OnfidoDocumentReport, OnfidoReport, SandboxVsLiveKYCRouteHandlerConfig } from "../../../types.js";
 import { getOnfidoCheckAsync } from "../get-check-async.js";
@@ -167,7 +167,7 @@ function createGetCredentialsV3(config: SandboxVsLiveKYCRouteHandlerConfig) {
 
         endpointLoggerV3.info({ uuidV2: uuidNew, check_id: checkIdFromNullifier }, "Issuing credentials");
 
-        await updateSessionStatus(config.SessionModel, checkIdFromNullifier, sessionStatusEnum.ISSUED);
+        await updateResolvedSessionStatus(session, sessionStatusEnum.ISSUED);
 
         return res.status(200).json(response);
       }
@@ -286,7 +286,7 @@ function createGetCredentialsV3(config: SandboxVsLiveKYCRouteHandlerConfig) {
       });
       await newNullifierAndCreds.save();
 
-      await updateSessionStatus(config.SessionModel, check_id, sessionStatusEnum.ISSUED);
+      await updateResolvedSessionStatus(session, sessionStatusEnum.ISSUED);
 
       return res.status(200).json(response);
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- update the already-resolved parent session during Onfido v3 credential issuance
- avoid legacy check_id lookup for standalone Onfido sessions
- cover both initial issuance and nullifier reissuance paths

## Validation
- bun run check:types