### PR TITLE
chore(deps): upgrade @zkpassport/sdk to ^0.16.0

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -16,7 +16,7 @@ WORKDIR /app
 
 RUN npm install -g bun@1.2.21
 
-COPY package*.json ./
+COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile
 
 COPY . .

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "@stellar/stellar-sdk": "^13.3.0",
         "@valkey/valkey-glide": "^2.0.1",
         "@verax-attestation-registry/verax-sdk": "^2.2.1",
-        "@zkpassport/sdk": "^0.14.2",
+        "@zkpassport/sdk": "^0.16.0",
         "aws-sdk": "^2.1295.0",
         "axios": "^1.13.2",
         "big-integer": "^1.6.51",
@@ -253,7 +253,9 @@
 
     "@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.201.0", "", { "dependencies": { "tslib": "^2.3.1" } }, "sha512-brRdB1wwMgjWEnOQsv7zSUhIQuh7DEicrfslAqHop4S4FtSI3GQAShpQqgOpMTNFYcpaWKmE/Y1MJmNY7xLCnw=="],
 
-    "@aztec/bb.js": ["@aztec/bb.js@4.2.0-aztecnr-rc.2", "", { "dependencies": { "comlink": "^4.4.1", "commander": "^12.1.0", "idb-keyval": "^6.2.1", "msgpackr": "^1.11.2", "pako": "^2.1.0", "tslib": "^2.4.0" }, "bin": { "bb": "dest/node/bin/index.js" } }, "sha512-ksFWHrm8QYAXP059paItEKCM/UhpHg5Dwl/eSp2BI6EAtD9+JlonkOwJ+94TYai2y5Gz0qnrgd65dsvDwJelVQ=="],
+    "@aztec/bb.js": ["@aztec/bb.js@5.0.0", "", { "dependencies": { "comlink": "^4.4.1", "commander": "^12.1.0", "idb-keyval": "^6.2.1", "msgpackr": "^1.11.2", "pako": "^2.1.0", "tslib": "^2.4.0" }, "bin": { "bb": "dest/node/bin/index.js" } }, "sha512-O4HDjzrjXMvM44+VbgDG1GaDUztWGEVujbBmwZAEVJh6BHpmJfMxBB2/69h1oi4kX2adgaowlJNFhpzcz1MHSA=="],
+
+    "@aztec/bb.js-v4": ["@aztec/bb.js@4.2.0-aztecnr-rc.2", "", { "dependencies": { "comlink": "^4.4.1", "commander": "^12.1.0", "idb-keyval": "^6.2.1", "msgpackr": "^1.11.2", "pako": "^2.1.0", "tslib": "^2.4.0" }, "bin": { "bb": "dest/node/bin/index.js" } }, "sha512-ksFWHrm8QYAXP059paItEKCM/UhpHg5Dwl/eSp2BI6EAtD9+JlonkOwJ+94TYai2y5Gz0qnrgd65dsvDwJelVQ=="],
 
     "@datadog/datadog-api-client": ["@datadog/datadog-api-client@1.16.0", "", { "dependencies": { "@types/buffer-from": "^1.1.0", "@types/node": "*", "@types/pako": "^1.0.3", "buffer-from": "^1.1.2", "cross-fetch": "^3.1.5", "es6-promise": "^4.2.8", "form-data": "^4.0.0", "loglevel": "^1.8.1", "pako": "^2.0.4", "url-parse": "^1.4.3" } }, "sha512-PnInPPyw3Ax8xcsAcJDIBUZcLSUWyFSdJc92Ac72+dKuoz79WBYw01naD9NRX0T9Ggv6mUOGILMq8BfpiHYfYA=="],
 
@@ -691,9 +693,9 @@
 
     "@zkpassport/registry": ["@zkpassport/registry@0.14.0", "", { "dependencies": { "@zkpassport/poseidon2": "^0.6.2", "@zkpassport/utils": "0.36.0", "debug": "^4.4.0", "tslib": "^2.8.1" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-6E6740NYx3wYIPZyWyIpNgnExJFHzSdZ4jzspTGHfKJalfpIQ8QMpTPSAruuHEymWD0c8qtz1kL9ioTjAp7GBA=="],
 
-    "@zkpassport/sdk": ["@zkpassport/sdk@0.14.2", "", { "dependencies": { "@aztec/bb.js": "4.2.0-aztecnr-rc.2", "@noble/ciphers": "^1.2.1", "@noble/hashes": "^2.0.1", "@noble/secp256k1": "^2.2.3", "@obsidion/bridge": "^0.11.2", "@zkpassport/registry": "0.14.0", "@zkpassport/utils": "0.36.0", "buffer": "^6.0.3", "i18n-iso-countries": "^7.12.0", "pako": "^2.1.0", "tslib": "^2.8.1", "viem": "^2.27.2", "ws": "^8.18.0" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-OdcRZ9WjNqzPZdatafQAZrV7w58B6e1DPa0JYJn/rwvMooQP8B85WnWlsaDcoBrly4b00zSHsJ3j3M7xLEEyEA=="],
+    "@zkpassport/sdk": ["@zkpassport/sdk@0.16.1", "", { "dependencies": { "@aztec/bb.js": "5.0.0", "@aztec/bb.js-v4": "npm:@aztec/bb.js@4.2.0-aztecnr-rc.2", "@noble/ciphers": "^1.2.1", "@noble/hashes": "^2.0.1", "@noble/secp256k1": "^2.2.3", "@obsidion/bridge": "^0.11.2", "@zkpassport/registry": "0.14.0", "@zkpassport/utils": "0.37.3", "buffer": "^6.0.3", "i18n-iso-countries": "^7.12.0", "pako": "^2.1.0", "tslib": "^2.8.1", "viem": "^2.27.2", "ws": "^8.18.0" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-ZcuO58vYphYNHysLPKBK9ISKoJ02sLWXGQ5jYhZzbj3DijL3U+tGVaPPotLfpQaVgEYIy9/Uv0xKh5fC3qC0zQ=="],
 
-    "@zkpassport/utils": ["@zkpassport/utils@0.36.0", "", { "dependencies": { "@lapo/asn1js": "^2.0.4", "@noble/ciphers": "^1.0.0", "@noble/curves": "^2.0.1", "@noble/hashes": "^2.0.1", "@noble/secp256k1": "^2.1.0", "@peculiar/asn1-cms": "^2.3.15", "@peculiar/asn1-ecc": "^2.3.15", "@peculiar/asn1-rsa": "^2.3.15", "@peculiar/asn1-schema": "^2.3.15", "@peculiar/asn1-x509": "^2.3.15", "@peculiar/x509": "^1.12.3", "@taceo/oprf-client": "^0.9.0", "@zk-kit/utils": "^1.2.1", "@zkpassport/poseidon2": "^0.6.2", "date-fns": "^4.1.0", "i18n-iso-countries": "^7.13.0", "tslib": "^2.8.1" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-FL1NCIqHASdSabnjIJIohm0HQi664XUhCxWPyZSdsN0KwXiBhrY3C7YGrW5XToxcXPnbVTy8/LAd3AXdVZcffQ=="],
+    "@zkpassport/utils": ["@zkpassport/utils@0.37.3", "", { "dependencies": { "@lapo/asn1js": "^2.0.4", "@noble/ciphers": "^1.0.0", "@noble/curves": "^2.0.1", "@noble/hashes": "^2.0.1", "@noble/secp256k1": "^2.1.0", "@peculiar/asn1-cms": "^2.3.15", "@peculiar/asn1-ecc": "^2.3.15", "@peculiar/asn1-rsa": "^2.3.15", "@peculiar/asn1-schema": "^2.3.15", "@peculiar/asn1-x509": "^2.3.15", "@peculiar/x509": "^1.12.3", "@taceo/oprf-client": "^0.9.0", "@taceo/oprf-core": "^0.4.0", "@zk-kit/utils": "^1.2.1", "@zkpassport/poseidon2": "^0.6.2", "date-fns": "^4.1.0", "i18n-iso-countries": "^7.13.0", "tslib": "^2.8.1" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-vqlFPm1SCjgG1kVX/IDN702c/tmB7XNCeP/MN+jaxg0sr2STMsQhXxTebqvvP3r6CdalDYV2m2IaCkWV0I47Nw=="],
 
     "abitype": ["abitype@1.0.7", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["zod"] }, "sha512-ZfYYSktDQUwc2eduYu8C4wOs+RDPmnRYMh7zNfzeMtGGgb0U+6tLGjixUic6mXf5xKKCcgT5Qp6cv39tOARVFw=="],
 
@@ -2335,6 +2337,8 @@
 
     "@zk-kit/utils/ethers": ["ethers@6.13.5", "", { "dependencies": { "@adraffy/ens-normalize": "1.10.1", "@noble/curves": "1.2.0", "@noble/hashes": "1.3.2", "@types/node": "22.7.5", "aes-js": "4.0.0-beta.5", "tslib": "2.7.0", "ws": "8.17.1" } }, "sha512-+knKNieu5EKRThQJWwqaJ10a6HE9sSehGeqWN65//wE7j47ZpFhKAnHB/JJFibwwg61I/koxaPsXbXpD/skNOQ=="],
 
+    "@zkpassport/registry/@zkpassport/utils": ["@zkpassport/utils@0.36.0", "", { "dependencies": { "@lapo/asn1js": "^2.0.4", "@noble/ciphers": "^1.0.0", "@noble/curves": "^2.0.1", "@noble/hashes": "^2.0.1", "@noble/secp256k1": "^2.1.0", "@peculiar/asn1-cms": "^2.3.15", "@peculiar/asn1-ecc": "^2.3.15", "@peculiar/asn1-rsa": "^2.3.15", "@peculiar/asn1-schema": "^2.3.15", "@peculiar/asn1-x509": "^2.3.15", "@peculiar/x509": "^1.12.3", "@taceo/oprf-client": "^0.9.0", "@zk-kit/utils": "^1.2.1", "@zkpassport/poseidon2": "^0.6.2", "date-fns": "^4.1.0", "i18n-iso-countries": "^7.13.0", "tslib": "^2.8.1" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-FL1NCIqHASdSabnjIJIohm0HQi664XUhCxWPyZSdsN0KwXiBhrY3C7YGrW5XToxcXPnbVTy8/LAd3AXdVZcffQ=="],
+
     "@zkpassport/registry/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "@zkpassport/sdk/@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
@@ -2740,6 +2744,12 @@
     "@zk-kit/utils/ethers/tslib": ["tslib@2.7.0", "", {}, "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="],
 
     "@zk-kit/utils/ethers/ws": ["ws@8.17.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="],
+
+    "@zkpassport/registry/@zkpassport/utils/@noble/curves": ["@noble/curves@2.2.0", "", { "dependencies": { "@noble/hashes": "2.2.0" } }, "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ=="],
+
+    "@zkpassport/registry/@zkpassport/utils/@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
+
+    "@zkpassport/registry/@zkpassport/utils/date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
 
     "@zkpassport/sdk/viem/@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@stellar/stellar-sdk": "^13.3.0",
     "@valkey/valkey-glide": "^2.0.1",
     "@verax-attestation-registry/verax-sdk": "^2.2.1",
-    "@zkpassport/sdk": "^0.15.1",
+    "@zkpassport/sdk": "^0.16.0",
     "aws-sdk": "^2.1295.0",
     "axios": "^1.13.2",
     "big-integer": "^1.6.51",


### PR DESCRIPTION
## Why

ZKPassport asked all integrators to move to **v0.16.0** ahead of a new mobile-app release landing in the next 2–3 days. Once that app ships, **only SDK v0.16.x will be compatible** with proofs generated by the app, so 0.15.x must be replaced before then.

## What changed

- Bump `@zkpassport/sdk` `^0.15.1` → `^0.16.0` in `package.json`.
- Regenerate `bun.lock`. The install resolves to **0.16.1** (the current `latest` dist-tag; its public type surface is byte-identical to 0.16.0). This pulls in the reworked proving backend — `@aztec/bb.js` `4.2.0-aztecnr-rc.2` → **5.0.0** (the SDK keeps a `@aztec/bb.js-v4` alias internally) — and `@zkpassport/utils` `0.36.0` → `0.37.3`. This is the "proving-system performance/reliability" upgrade ZKPassport described.
- The regeneration also corrects a stale lockfile that still recorded `@zkpassport/sdk@0.14.2` even though `0.15.1` was installed.

## No source changes were required

Diffing the 0.15.1 vs 0.16.x TypeScript definitions, the **only** public-API change is a new **optional** `request()` parameter (`returnDeepLink`) plus a doc-comment tweak. Every method and return shape this service uses is unchanged:

- `new ZKPassport(domain, { disableProofStorage })`
- `createQuery().disclose().facematch("regular").sanctions().done().query`
- `verify({ proofs, originalQuery, queryResult })` → `{ verified, queryResultErrors, uniqueIdentifier }`

Affected call sites: `src/services/zk-passport/verify-and-issue.ts`, `src/services/aml-sessions/endpoints.ts`.

## Validation

- `bun run check:types` (`tsc --noEmit`) — passes clean.
- Runtime smoke test under bun: the SDK imports with the new bb.js 5.0.0 backend, instantiates, and builds both the issuance and clean-hands (`.sanctions()`) offline queries used by `verify()`.

> Note: proof-generation compatibility with the new mobile app can only be fully verified end-to-end against the app once it's released; the SDK-side upgrade is complete and API-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)