### PR TITLE
fix(zk-passport): stop dumping proofs and disclosed PII to /tmp

### DIFF
--- a/src/services/aml-sessions/endpoints.ts
+++ b/src/services/aml-sessions/endpoints.ts
@@ -2672,7 +2672,7 @@ function createVerifyAndIssueZkPassportRouteHandler(
         },
         "Verifying ZK Passport proofs (pre-verify diagnostic)",
       );
-      dumpZkPassportPayload("aml-sessions", { proofs, queryResult, sid: session._id });
+      // dumpZkPassportPayload("aml-sessions", { proofs, queryResult, sid: session._id });
 
       let verificationResult: any;
       try {

--- a/src/services/zk-passport/verify-and-issue.ts
+++ b/src/services/zk-passport/verify-and-issue.ts
@@ -433,7 +433,7 @@ function createVerifyAndIssue(config: SandboxVsLiveKYCRouteHandlerConfig) {
         },
         "Verifying ZK Passport proofs (pre-verify diagnostic)",
       );
-      dumpZkPassportPayload("verify-and-issue", { proofs, queryResult, sid: session._id });
+      //dumpZkPassportPayload("verify-and-issue", { proofs, queryResult, sid: session._id });
 
       let verificationResult;
       try {


### PR DESCRIPTION
The pre-verify diagnostic added in d3d4593 appended the full proofs and queryResult payload to /tmp/zk-passport-payloads.jsonl on every ZK Passport verification attempt. queryResult carries disclosed passport PII (firstname, lastname, birthdate, nationality) in plaintext, written world-readable to a fixed path with no gating, rotation, or retention policy, on both the paid gov-id and Clean Hands paths.

Comment out both call sites. The endpointLogger.info calls immediately above each one still record proof count, proof sizes, and queryResultKeys, so the crash diagnostic keeps its signal without the payload.


Claude-Session: https://claude.ai/code/session_011TRahMrKgCmJNu7dgbfRsS