### PR TITLE
fix(onfido): add optional chaining to webhook payload parsing

### DIFF
--- a/src/services/onfido/webhooks.ts
+++ b/src/services/onfido/webhooks.ts
@@ -160,9 +160,9 @@ function createHandleOnfidoWebhookRouteHandler(config: SandboxVsLiveKYCRouteHand
       }
 
       // Parse the event - handle different payload structures
-      let eventType = body?.payload.resource_type;
-      let action = body?.payload.action;
-      let object = body?.payload.object;
+      let eventType = body?.payload?.resource_type;
+      let action = body?.payload?.action;
+      let object = body?.payload?.object;
 
       // Handle different event types
       switch (eventType) {


### PR DESCRIPTION
## Summary
Adds optional chaining to Onfido webhook payload field accesses. `body?.payload.resource_type` throws TypeError if `payload` is undefined (ping events, test events, non-standard formats). Changed to `body?.payload?.resource_type`.

Found via proactive Datadog audit — 9 crashes in 7 days (~1-2/day).

Refs holonym-foundation/internal-docs#1835

## Changes
```diff
- let eventType = body?.payload.resource_type;
- let action = body?.payload.action;
- let object = body?.payload.object;
+ let eventType = body?.payload?.resource_type;
+ let action = body?.payload?.action;
+ let object = body?.payload?.object;
```

## Test plan
- [ ] Webhook with standard `payload` structure still processes correctly
- [ ] Webhook without `payload` key logs "Unhandled webhook event type" instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)