### PR TITLE
feat(payments): label environment in /payments/status responses

### DIFF
--- a/src/services/payments/endpoints.ts
+++ b/src/services/payments/endpoints.ts
@@ -369,63 +369,74 @@ async function requestRefundSandbox(req: Request, res: Response) {
 /**
  * GET /payments/status
  * Check payment status (redeemed, unredeemed, pending-redemption, pending-refund, refunded)
+ *
+ * Every response—including errors—includes the "environment" of the route that
+ * served it ("live" or "sandbox"). The sandbox route reads sandbox DB
+ * collections but the same real chains, so a live payment queried through
+ * /sandbox/payments/status looks like a genuine "unredeemed" payment. Labeling
+ * the environment makes that mistake self-evident to whoever reads the response.
  */
 function createPaymentStatusRouteHandler(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
+    const environment = config.environment;
     try {
       const { commitment, chainId } = req.query;
 
       if (!commitment || typeof commitment !== "string") {
-        return res.status(400).json({ error: "commitment is required" });
+        return res.status(400).json({ error: "commitment is required", environment });
       }
       if (chainId === undefined || chainId === null) {
-        return res.status(400).json({ error: "chainId is required" });
+        return res.status(400).json({ error: "chainId is required", environment });
       }
 
       const chainIdNum = typeof chainId === "number" ? chainId : Number(chainId);
       if (isNaN(chainIdNum)) {
-        return res.status(400).json({ error: "chainId must be a number" });
+        return res.status(400).json({ error: "chainId must be a number", environment });
       }
 
       // Validate chainId and get contract address
       const contractAddress = humanIDPaymentsContractAddresses[chainIdNum];
       if (!contractAddress) {
-        return res.status(400).json({ error: `Unsupported chain ID: ${chainIdNum}` });
+        return res
+          .status(400)
+          .json({ error: `Unsupported chain ID: ${chainIdNum}`, environment });
       }
 
       // Check if payment exists onchain
       const payment = await getPaymentFromContract(commitment, chainIdNum, contractAddress);
 
       if (!payment) {
-        return res.status(404).json({ error: "Payment not found onchain" });
+        return res.status(404).json({ error: "Payment not found onchain", environment });
       }
 
       if (payment.refunded) {
-        return res.status(200).json({ status: "refunded", payment })
+        return res.status(200).json({ status: "refunded", payment, environment })
       }
 
       const commitmentRecord = await config.PaymentCommitmentModel.findOne({ commitment }).exec();
 
       // Check if already redeemed
       if (await isPaymentRedeemed(commitmentRecord, config.PaymentRedemptionModel)) {
-        return res.status(200).json({ status: "redeemed", payment });
+        return res.status(200).json({ status: "redeemed", payment, environment });
       }
 
       // Check if redemption is pending
       if (await isRedemptionPending(commitment, config.environment)) {
-        return res.status(200).json({ status: "pending-redemption", payment });
+        return res.status(200).json({ status: "pending-redemption", payment, environment });
       }
 
       // Check if refund is pending
       if (await isRefundPending(commitment, config.environment)) {
-        return res.status(200).json({ status: "pending-refund", payment });
+        return res.status(200).json({ status: "pending-refund", payment, environment });
       }
 
       // Payment exists but no redemption or pending operations
-      return res.status(200).json({ status: "unredeemed", payment });
+      return res.status(200).json({ status: "unredeemed", payment, environment });
     } catch (error: any) {
-      paymentsLogger.error({ error: error.message }, "Error checking payment status");
-      return res.status(500).json({ error: error.message || "An unknown error occurred" });
+      paymentsLogger.error({ error: error.message, environment }, "Error checking payment status");
+      return res
+        .status(500)
+        .json({ error: error.message || "An unknown error occurred", environment });
     }
   };
 }


### PR DESCRIPTION
Implements fix 3 from holonym-foundation/internal-docs#236 ("Label the environment in status responses").

## Why

`/sandbox/payments/status` reads the sandbox Mongo collections but the *same real chains*. So a genuinely redeemed live payment queried through the sandbox base path returns `{"status": "unredeemed", "payment": {…real onchain details…}}` — an answer that looks authoritative and is wrong for the question being asked. In the incident behind #236, support read three such `unredeemed` responses for three fulfilled verifications and refunded two of them.

Nothing in the response body said which environment answered.

## What changed

`createPaymentStatusRouteHandler` (`src/services/payments/endpoints.ts`) now includes `"environment": "live" | "sandbox"` (from the route handler config it already has) in **every** response it returns — the five success statuses and the 400/404/500 error bodies alike. Errors are included deliberately: `404 Payment not found onchain` from the sandbox route is exactly the kind of answer someone would otherwise misread as "this payment doesn't exist".

The handler's error log line is also tagged with the environment.

Purely additive to the response shape; no existing field changes and no behavior depends on it server-side.

## Verification

- `pnpm check:types` (`tsc --noEmit`) — clean.
- Companion PR in the monorepo (holonym-foundation/human-id) adds the optional `environment` field to the frontend `PaymentStatusResponse` type, logs it alongside the payment status in the existing DEBUG_PAYMENT_APRIL_2026 Datadog line, and documents the sandbox pitfall in the Credits dev docs.

## Scope note

This is fix 3 only. Fixes 1, 2, 4, and 5 from the ticket (commitment case normalization, distinguishing "no DB record" from "unredeemed", the admin force-refund guard, and the orphaned-session hole) are not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxqrkLcPQSmHcw7jtHjC2N