### PR TITLE
fix(payments): normalize commitment strings at API boundaries

### DIFF
--- a/src/services/admin/refund-payment.ts
+++ b/src/services/admin/refund-payment.ts
@@ -4,6 +4,8 @@ import {
   getRedemptionRecord,
   isPaymentRedeemed,
   isRedemptionPending,
+  normalizeCommitment,
+  INVALID_COMMITMENT_MESSAGE,
 } from "../payments/functions.js";
 import { pinoOptions, logger } from "../../utils/logger.js";
 import { getRouteHandlerConfig } from "../../init.js";
@@ -101,7 +103,7 @@ export async function refundPayment(req: Request, res: Response) {
     const liveConfig = getRouteHandlerConfig("live");
     const sandboxConfig = getRouteHandlerConfig("sandbox");
 
-    const { commitment, chainId, allowRedeemed } = req.body;
+    const { commitment: rawCommitment, chainId, allowRedeemed } = req.body;
 
     const apiKey = req.headers["x-api-key"];
     if (!process.env.ADMIN_API_KEY_LOW_PRIVILEGE || !apiKey) {
@@ -111,8 +113,9 @@ export async function refundPayment(req: Request, res: Response) {
       return res.status(401).json({ error: "Invalid API key." });
     }
 
-    if (!commitment || typeof commitment !== "string") {
-      return res.status(400).json({ error: "commitment is required" });
+    const commitment = normalizeCommitment(rawCommitment);
+    if (!commitment) {
+      return res.status(400).json({ error: INVALID_COMMITMENT_MESSAGE });
     }
     if (chainId === undefined || chainId === null) {
       return res.status(400).json({ error: "chainId is required" });
@@ -122,18 +125,9 @@ export async function refundPayment(req: Request, res: Response) {
       return res.status(400).json({ error: "chainId must be a number" });
     }
 
-    // Every commitment we write today is lowercase (ethers-derived, or a
-    // client-supplied string that must match one to be redeemable), while the
-    // Mongo lookup is a case-sensitive string match — so lowercasing the input
-    // is what makes an uppercase commitment find its record instead of looking
-    // unredeemed. Note the schema does not enforce lowercase storage, so this
-    // does not help if a record was somehow stored uppercase; normalizing at
-    // every commitment boundary (fix 1 of internal-docs#236) is what would.
-    const normalizedCommitment = commitment.toLowerCase();
-
     const inspections = await Promise.all([
-      inspectRedemption(liveConfig, normalizedCommitment),
-      inspectRedemption(sandboxConfig, normalizedCommitment),
+      inspectRedemption(liveConfig, commitment),
+      inspectRedemption(sandboxConfig, commitment),
     ]);
     const redeemedIn = inspections.filter((i) => i.redeemed);
     const redeemed = redeemedIn.length > 0;
@@ -141,7 +135,7 @@ export async function refundPayment(req: Request, res: Response) {
     const overrideRequested = allowRedeemed === true || allowRedeemed === "true";
 
     const auditBase = {
-      commitment: normalizedCommitment,
+      commitment,
       chainId: chainIdNum,
       redeemed,
       redeemedIn: redeemedIn.map((i) => i.environment),
@@ -171,7 +165,7 @@ export async function refundPayment(req: Request, res: Response) {
     // A redemption in flight in either environment must also block the refund.
     // `forceRefundPayment` only checks the environment it is given, and the
     // pending keys are environment-prefixed.
-    if (await isRedemptionPending(normalizedCommitment, "sandbox")) {
+    if (await isRedemptionPending(commitment, "sandbox")) {
       adminRefundPaymentLogger.info(
         auditBase,
         "Admin force-refund rejected: redemption is pending in the sandbox environment"
@@ -194,7 +188,7 @@ export async function refundPayment(req: Request, res: Response) {
       );
     }
 
-    const result = await forceRefundPayment(normalizedCommitment, chainIdNum, {
+    const result = await forceRefundPayment(commitment, chainIdNum, {
       logger: adminRefundPaymentLogger,
       environment: liveConfig.environment,
     });
@@ -226,7 +220,7 @@ export async function refundPayment(req: Request, res: Response) {
 
     return res.status(200).json({
       message: "Refund processed successfully",
-      commitment: normalizedCommitment,
+      commitment,
       chainId: chainIdNum,
       contractAddress: result.contractAddress,
       txHash: result.txHash,

--- a/src/services/payment-secrets.ts
+++ b/src/services/payment-secrets.ts
@@ -256,22 +256,30 @@ function createPutPaymentSecret(config: SandboxVsLiveKYCRouteHandlerConfig) {
     const rawCommitment = req?.body?.commitment;
     const encryptedSecret = req?.body?.encryptedSecret;
 
-    // Normalize before validation/storage so a non-lowercase commitment can
-    // never be persisted (Mongo string matching is case-sensitive).
-    const commitment = normalizeCommitment(rawCommitment);
-    if (!commitment) {
-      putEndpointLogger.error({ commitment: rawCommitment }, "Invalid commitment format");
-      return res.status(400).json({ error: INVALID_COMMITMENT_MESSAGE });
-    }
-
     const validationResult = await validatePutPaymentSecretArgs(
       holoUserId,
-      commitment,
+      rawCommitment,
       encryptedSecret
     );
     if (validationResult.error) {
       putEndpointLogger.error({ error: validationResult.error }, "Invalid request body");
       return res.status(400).json({ error: validationResult.error });
+    }
+
+    // Normalize before storage so a non-lowercase commitment can never be
+    // persisted (Mongo string matching is case-sensitive). Don't log the raw
+    // value: a client that transposes the commitment and secret fields would
+    // otherwise land a payment secret in the logs.
+    const commitment = normalizeCommitment(rawCommitment);
+    if (!commitment) {
+      putEndpointLogger.error(
+        {
+          commitmentType: typeof rawCommitment,
+          commitmentLength: typeof rawCommitment === "string" ? rawCommitment.length : null,
+        },
+        "Invalid commitment format"
+      );
+      return res.status(400).json({ error: INVALID_COMMITMENT_MESSAGE });
     }
 
     const storeOrUpdateResult = await storeOrUpdatePaymentSecret(

--- a/src/services/payment-secrets.ts
+++ b/src/services/payment-secrets.ts
@@ -9,7 +9,12 @@ import {
   IPaymentCommitment,
   SandboxVsLiveKYCRouteHandlerConfig
 } from "../types.js";
-import { getRedemptionRecord, createCommitmentRecord } from "./payments/functions.js";
+import {
+  getRedemptionRecord,
+  createCommitmentRecord,
+  normalizeCommitment,
+  INVALID_COMMITMENT_MESSAGE,
+} from "./payments/functions.js";
 
 const getEndpointLogger = logger.child({ msgPrefix: "[GET /payment-secrets] " });
 const putEndpointLogger = logger.child({ msgPrefix: "[PUT /payment-secrets] " });
@@ -248,8 +253,16 @@ async function getPaymentSecretsSandbox(req: Request, res: Response) {
 function createPutPaymentSecret(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
     const holoUserId = req?.body?.holoUserId;
-    const commitment = req?.body?.commitment;
+    const rawCommitment = req?.body?.commitment;
     const encryptedSecret = req?.body?.encryptedSecret;
+
+    // Normalize before validation/storage so a non-lowercase commitment can
+    // never be persisted (Mongo string matching is case-sensitive).
+    const commitment = normalizeCommitment(rawCommitment);
+    if (!commitment) {
+      putEndpointLogger.error({ commitment: rawCommitment }, "Invalid commitment format");
+      return res.status(400).json({ error: INVALID_COMMITMENT_MESSAGE });
+    }
 
     const validationResult = await validatePutPaymentSecretArgs(
       holoUserId,

--- a/src/services/payments/commitment.test.ts
+++ b/src/services/payments/commitment.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "bun:test";
 import { ethers } from "ethers";
-import { normalizeCommitment, INVALID_COMMITMENT_MESSAGE } from "./commitment.js";
+import {
+  normalizeCommitment,
+  createCommitmentRecord,
+  INVALID_COMMITMENT_MESSAGE,
+} from "./commitment.js";
 
 // Same derivation as deriveCommitmentFromSecret in ./functions.js (which can't
 // be imported here without dragging in env-dependent module init).
@@ -74,5 +78,56 @@ describe("normalizeCommitment", () => {
     expect(INVALID_COMMITMENT_MESSAGE).toBe(
       "commitment must be a 0x-prefixed 32-byte hex string"
     );
+  });
+});
+
+describe("createCommitmentRecord", () => {
+  function stubModel() {
+    const calls = { findOne: [] as any[], create: [] as any[] };
+    const model = {
+      findOne(query: any) {
+        calls.findOne.push(query);
+        return { exec: async () => null };
+      },
+      async create(doc: any) {
+        calls.create.push(doc);
+        return doc;
+      },
+    };
+    return { model: model as any, calls };
+  }
+
+  it("throws on a malformed commitment before touching the model", async () => {
+    const { model, calls } = stubModel();
+    await expect(
+      createCommitmentRecord("not-a-commitment", "user", model)
+    ).rejects.toThrow(INVALID_COMMITMENT_MESSAGE);
+    expect(calls.findOne).toHaveLength(0);
+    expect(calls.create).toHaveLength(0);
+  });
+
+  it("queries and persists the lowercased commitment", async () => {
+    const { model, calls } = stubModel();
+    const upper = "0x" + VALID_LOWERCASE.slice(2).toUpperCase();
+    const record = await createCommitmentRecord(upper, "user", model);
+    expect(calls.findOne[0]).toEqual({ commitment: VALID_LOWERCASE });
+    expect(calls.create[0].commitment).toBe(VALID_LOWERCASE);
+    expect(record.commitment).toBe(VALID_LOWERCASE);
+  });
+
+  it("returns an existing record without creating a duplicate", async () => {
+    const { model, calls } = stubModel();
+    const existing = {
+      commitment: VALID_LOWERCASE,
+      sourceType: "user" as const,
+      createdAt: new Date(0),
+    };
+    model.findOne = (query: any) => {
+      calls.findOne.push(query);
+      return { exec: async () => existing };
+    };
+    const record = await createCommitmentRecord(VALID_LOWERCASE, "user", model);
+    expect(record).toBe(existing);
+    expect(calls.create).toHaveLength(0);
   });
 });

--- a/src/services/payments/commitment.test.ts
+++ b/src/services/payments/commitment.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "bun:test";
+import { ethers } from "ethers";
+import { normalizeCommitment, INVALID_COMMITMENT_MESSAGE } from "./commitment.js";
+
+// Same derivation as deriveCommitmentFromSecret in ./functions.js (which can't
+// be imported here without dragging in env-dependent module init).
+function deriveCommitment(secret: string): string {
+  return ethers.utils.keccak256(ethers.utils.toUtf8Bytes(secret));
+}
+
+const VALID_LOWERCASE =
+  "0x6fbc0fcf0000000000000000000000000000000000000000000000000000c9c2" as const;
+
+describe("normalizeCommitment", () => {
+  it("returns a valid lowercase commitment unchanged", () => {
+    expect(normalizeCommitment(VALID_LOWERCASE)).toBe(VALID_LOWERCASE);
+
+    const derived = deriveCommitment("test");
+    expect(normalizeCommitment(derived)).toBe(derived);
+  });
+
+  it("lowercases uppercase hex digits", () => {
+    const upper = "0x" + VALID_LOWERCASE.slice(2).toUpperCase();
+    expect(normalizeCommitment(upper)).toBe(VALID_LOWERCASE);
+  });
+
+  it("lowercases mixed/checksummed-style case", () => {
+    const mixed =
+      "0x6FbC0fCf0000000000000000000000000000000000000000000000000000C9c2";
+    expect(normalizeCommitment(mixed)).toBe(mixed.toLowerCase());
+  });
+
+  it("normalizes an uppercased derived commitment back to the derived value (issue #236 scenario)", () => {
+    const derived = deriveCommitment("some payment secret");
+    const uppercased = "0x" + derived.slice(2).toUpperCase();
+    expect(normalizeCommitment(uppercased)).toBe(derived);
+  });
+
+  it("rejects an uppercase 0X prefix", () => {
+    const upperPrefix = "0X" + VALID_LOWERCASE.slice(2);
+    expect(normalizeCommitment(upperPrefix)).toBeNull();
+  });
+
+  it("rejects hex without the 0x prefix", () => {
+    expect(normalizeCommitment(VALID_LOWERCASE.slice(2))).toBeNull();
+  });
+
+  it("rejects wrong lengths", () => {
+    expect(normalizeCommitment(VALID_LOWERCASE.slice(0, -1))).toBeNull(); // 63 chars
+    expect(normalizeCommitment(VALID_LOWERCASE + "a")).toBeNull(); // 65 chars
+    expect(normalizeCommitment("0x")).toBeNull();
+    expect(normalizeCommitment("")).toBeNull();
+  });
+
+  it("rejects non-hex characters", () => {
+    expect(normalizeCommitment(VALID_LOWERCASE.slice(0, -1) + "g")).toBeNull();
+  });
+
+  it("rejects whitespace-padded values (no trimming)", () => {
+    expect(normalizeCommitment(` ${VALID_LOWERCASE}`)).toBeNull();
+    expect(normalizeCommitment(`${VALID_LOWERCASE}\n`)).toBeNull();
+  });
+
+  it("rejects non-string values", () => {
+    expect(normalizeCommitment(null)).toBeNull();
+    expect(normalizeCommitment(undefined)).toBeNull();
+    expect(normalizeCommitment(123)).toBeNull();
+    expect(normalizeCommitment({})).toBeNull();
+    // Express yields arrays for repeated query params
+    expect(normalizeCommitment([VALID_LOWERCASE])).toBeNull();
+  });
+
+  it("exports a stable error message for endpoint 400s", () => {
+    expect(INVALID_COMMITMENT_MESSAGE).toBe(
+      "commitment must be a 0x-prefixed 32-byte hex string"
+    );
+  });
+});

--- a/src/services/payments/commitment.ts
+++ b/src/services/payments/commitment.ts
@@ -1,0 +1,15 @@
+export const INVALID_COMMITMENT_MESSAGE =
+  "commitment must be a 0x-prefixed 32-byte hex string";
+
+/**
+ * Validate that a value is a 0x-prefixed 32-byte hex string (a payment
+ * commitment) and return it lowercased. Returns null for anything else.
+ * NEVER apply this to payment secrets: commitments are keccak256 of the
+ * secret's exact UTF-8 string, so changing a secret's case changes the digest.
+ */
+export function normalizeCommitment(raw: unknown): string | null {
+  if (typeof raw !== "string" || !/^0x[0-9a-fA-F]{64}$/.test(raw)) {
+    return null;
+  }
+  return raw.toLowerCase();
+}

--- a/src/services/payments/commitment.ts
+++ b/src/services/payments/commitment.ts
@@ -1,3 +1,6 @@
+import type { Model } from "mongoose";
+import type { IPaymentCommitment } from "../../types.js";
+
 export const INVALID_COMMITMENT_MESSAGE =
   "commitment must be a 0x-prefixed 32-byte hex string";
 
@@ -12,4 +15,30 @@ export function normalizeCommitment(raw: unknown): string | null {
     return null;
   }
   return raw.toLowerCase();
+}
+
+/**
+ * Create commitment record in PaymentCommitments collection
+ */
+export async function createCommitmentRecord(
+  commitment: string,
+  sourceType: 'user' | 'credits',
+  PaymentCommitmentModel: Model<IPaymentCommitment>
+): Promise<IPaymentCommitment> {
+  // Guard against ever persisting a non-lowercase or malformed commitment,
+  // which would bypass the case-sensitive unique index on `commitment`.
+  const normalized = normalizeCommitment(commitment);
+  if (!normalized) {
+    throw new Error(`Invalid commitment format: ${INVALID_COMMITMENT_MESSAGE}`);
+  }
+  // Check if commitment already exists
+  const existing = await PaymentCommitmentModel.findOne({ commitment: normalized }).exec();
+  if (existing) {
+    return existing;
+  }
+  return await PaymentCommitmentModel.create({
+    commitment: normalized,
+    sourceType,
+    createdAt: new Date(),
+  });
 }

--- a/src/services/payments/endpoints.ts
+++ b/src/services/payments/endpoints.ts
@@ -11,6 +11,8 @@ import {
   isPaymentRedeemed,
   findRedemptionRecord,
   deriveCommitmentFromSecret,
+  normalizeCommitment,
+  INVALID_COMMITMENT_MESSAGE,
   reserveRedemption,
   completeRedemption,
   cancelRedemption,
@@ -42,10 +44,11 @@ const paymentsLogger = logger.child({
 function createCreatePaymentParamsRouteHandler(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
     try {
-      const { commitment, service, chainId } = req.query;
+      const { commitment: rawCommitment, service, chainId } = req.query;
 
-      if (!commitment || typeof commitment !== "string") {
-        return res.status(400).json({ error: "commitment is required" });
+      const commitment = normalizeCommitment(rawCommitment);
+      if (!commitment) {
+        return res.status(400).json({ error: INVALID_COMMITMENT_MESSAGE });
       }
       if (!service || typeof service !== "string") {
         return res.status(400).json({ error: "service is required" });
@@ -386,10 +389,11 @@ function createPaymentStatusRouteHandler(config: SandboxVsLiveKYCRouteHandlerCon
   return async (req: Request, res: Response) => {
     const environment = config.environment;
     try {
-      const { commitment, chainId } = req.query;
+      const { commitment: rawCommitment, chainId } = req.query;
 
-      if (!commitment || typeof commitment !== "string") {
-        return res.status(400).json({ error: "commitment is required", environment });
+      const commitment = normalizeCommitment(rawCommitment);
+      if (!commitment) {
+        return res.status(400).json({ error: INVALID_COMMITMENT_MESSAGE, environment });
       }
       if (chainId === undefined || chainId === null) {
         return res.status(400).json({ error: "chainId is required", environment });

--- a/src/services/payments/functions.ts
+++ b/src/services/payments/functions.ts
@@ -19,6 +19,7 @@ import { usdToETH, usdToFTM, usdToAVAX } from "../../utils/cmc.js";
 import { getProvider } from '../../utils/misc.js';
 import { IPaymentRedemption, IPaymentCommitment, IHumanIDCreditsPaymentSecret, ISandboxHumanIDCreditsPaymentSecret } from "../../types.js";
 import { pinoOptions, logger } from "../../utils/logger.js";
+import { normalizeCommitment, INVALID_COMMITMENT_MESSAGE } from "./commitment.js";
 
 const paymentsLogger = logger.child({
   base: {
@@ -430,6 +431,8 @@ export function deriveCommitmentFromSecret(secret: string): string {
   return ethers.utils.keccak256(ethers.utils.toUtf8Bytes(secret));
 }
 
+export { normalizeCommitment, INVALID_COMMITMENT_MESSAGE };
+
 /**
  * Verify commitment secret by hashing it and comparing with commitment
  */
@@ -479,13 +482,19 @@ export async function createCommitmentRecord(
   sourceType: 'user' | 'credits',
   PaymentCommitmentModel: Model<IPaymentCommitment>
 ): Promise<IPaymentCommitment> {
+  // Guard against ever persisting a non-lowercase or malformed commitment,
+  // which would bypass the case-sensitive unique index on `commitment`.
+  const normalized = normalizeCommitment(commitment);
+  if (!normalized) {
+    throw new Error(`Invalid commitment format: ${INVALID_COMMITMENT_MESSAGE}`);
+  }
   // Check if commitment already exists
-  const existing = await PaymentCommitmentModel.findOne({ commitment }).exec();
+  const existing = await PaymentCommitmentModel.findOne({ commitment: normalized }).exec();
   if (existing) {
     return existing;
   }
   return await PaymentCommitmentModel.create({
-    commitment,
+    commitment: normalized,
     sourceType,
     createdAt: new Date(),
   });

--- a/src/services/payments/functions.ts
+++ b/src/services/payments/functions.ts
@@ -19,7 +19,11 @@ import { usdToETH, usdToFTM, usdToAVAX } from "../../utils/cmc.js";
 import { getProvider } from '../../utils/misc.js';
 import { IPaymentRedemption, IPaymentCommitment, IHumanIDCreditsPaymentSecret, ISandboxHumanIDCreditsPaymentSecret } from "../../types.js";
 import { pinoOptions, logger } from "../../utils/logger.js";
-import { normalizeCommitment, INVALID_COMMITMENT_MESSAGE } from "./commitment.js";
+import {
+  normalizeCommitment,
+  INVALID_COMMITMENT_MESSAGE,
+  createCommitmentRecord,
+} from "./commitment.js";
 
 const paymentsLogger = logger.child({
   base: {
@@ -328,9 +332,12 @@ export async function getRedemptionRecord(
 ): Promise<IPaymentRedemption | null> {
   // Use aggregation pipeline to join PaymentCommitment and PaymentRedemption in a single query
   const pipeline = [
-    // Stage 1: Match PaymentCommitment by commitment string
+    // Stage 1: Match PaymentCommitment by commitment string. Match on the
+    // lowercase form: redemptions only ever attach to lowercase rows (they are
+    // looked up via the derived commitment), so a legacy mixed-case row passed
+    // in here would otherwise miss its redemption and look unspent.
     {
-      $match: { commitment }
+      $match: { commitment: commitment.toLowerCase() }
     },
     // Stage 2: Lookup PaymentRedemption by commitmentId
     {
@@ -431,7 +438,7 @@ export function deriveCommitmentFromSecret(secret: string): string {
   return ethers.utils.keccak256(ethers.utils.toUtf8Bytes(secret));
 }
 
-export { normalizeCommitment, INVALID_COMMITMENT_MESSAGE };
+export { normalizeCommitment, INVALID_COMMITMENT_MESSAGE, createCommitmentRecord };
 
 /**
  * Verify commitment secret by hashing it and comparing with commitment
@@ -472,32 +479,6 @@ export async function getCommitmentRecord(
   PaymentCommitmentModel: Model<IPaymentCommitment>
 ): Promise<IPaymentCommitment | null> {
   return await PaymentCommitmentModel.findOne({ commitment }).exec();
-}
-
-/**
- * Create commitment record in PaymentCommitments collection
- */
-export async function createCommitmentRecord(
-  commitment: string,
-  sourceType: 'user' | 'credits',
-  PaymentCommitmentModel: Model<IPaymentCommitment>
-): Promise<IPaymentCommitment> {
-  // Guard against ever persisting a non-lowercase or malformed commitment,
-  // which would bypass the case-sensitive unique index on `commitment`.
-  const normalized = normalizeCommitment(commitment);
-  if (!normalized) {
-    throw new Error(`Invalid commitment format: ${INVALID_COMMITMENT_MESSAGE}`);
-  }
-  // Check if commitment already exists
-  const existing = await PaymentCommitmentModel.findOne({ commitment: normalized }).exec();
-  if (existing) {
-    return existing;
-  }
-  return await PaymentCommitmentModel.create({
-    commitment: normalized,
-    sourceType,
-    createdAt: new Date(),
-  });
 }
 
 // ─── Extracted Redemption Business Logic ────────────────────────────────────

--- a/src/services/payments/human-id-credits/functions.ts
+++ b/src/services/payments/human-id-credits/functions.ts
@@ -12,13 +12,7 @@ import {
   IHumanIDCreditsPaymentSecret,
   IHumanIDCreditsPriceOverride,
 } from '../../../types.js';
-import {
-  deriveCommitmentFromSecret,
-  normalizeCommitment,
-  INVALID_COMMITMENT_MESSAGE,
-  generatePaymentSignature,
-  calculatePriceInToken,
-} from '../functions.js';
+import { deriveCommitmentFromSecret, generatePaymentSignature, calculatePriceInToken } from '../functions.js';
 import {
   idvSessionUSDPrice,
   PAYMENT_SERVICE_SBT_MINT,
@@ -276,45 +270,6 @@ export async function commitmentExists(
 ): Promise<boolean> {
   const exists = await PaymentCommitmentModel.findOne({ commitment }).exec();
   return exists !== null;
-}
-
-/**
- * Get commitment record
- */
-export async function getCommitmentRecord(
-  commitment: string,
-  PaymentCommitmentModel: Model<IPaymentCommitment>
-): Promise<IPaymentCommitment | null> {
-  return await PaymentCommitmentModel.findOne({ commitment }).exec();
-}
-
-/**
- * Create commitment record
- */
-export async function createCommitmentRecord(
-  commitment: string,
-  sourceType: 'user' | 'credits',
-  PaymentCommitmentModel: Model<IPaymentCommitment>
-): Promise<Types.ObjectId> {
-  // Guard against ever persisting a non-lowercase or malformed commitment,
-  // which would bypass the case-sensitive unique index on `commitment`.
-  const normalized = normalizeCommitment(commitment);
-  if (!normalized) {
-    throw new Error(`Invalid commitment format: ${INVALID_COMMITMENT_MESSAGE}`);
-  }
-  // Check if commitment already exists
-  const existing = await PaymentCommitmentModel.findOne({ commitment: normalized }).exec();
-  if (existing) {
-    return existing._id!;
-  }
-
-  const commitmentRecord = await PaymentCommitmentModel.create({
-    commitment: normalized,
-    sourceType,
-    createdAt: new Date(),
-  });
-
-  return commitmentRecord._id!;
 }
 
 /**

--- a/src/services/payments/human-id-credits/functions.ts
+++ b/src/services/payments/human-id-credits/functions.ts
@@ -12,7 +12,13 @@ import {
   IHumanIDCreditsPaymentSecret,
   IHumanIDCreditsPriceOverride,
 } from '../../../types.js';
-import { deriveCommitmentFromSecret, generatePaymentSignature, calculatePriceInToken } from '../functions.js';
+import {
+  deriveCommitmentFromSecret,
+  normalizeCommitment,
+  INVALID_COMMITMENT_MESSAGE,
+  generatePaymentSignature,
+  calculatePriceInToken,
+} from '../functions.js';
 import {
   idvSessionUSDPrice,
   PAYMENT_SERVICE_SBT_MINT,
@@ -290,14 +296,20 @@ export async function createCommitmentRecord(
   sourceType: 'user' | 'credits',
   PaymentCommitmentModel: Model<IPaymentCommitment>
 ): Promise<Types.ObjectId> {
+  // Guard against ever persisting a non-lowercase or malformed commitment,
+  // which would bypass the case-sensitive unique index on `commitment`.
+  const normalized = normalizeCommitment(commitment);
+  if (!normalized) {
+    throw new Error(`Invalid commitment format: ${INVALID_COMMITMENT_MESSAGE}`);
+  }
   // Check if commitment already exists
-  const existing = await PaymentCommitmentModel.findOne({ commitment }).exec();
+  const existing = await PaymentCommitmentModel.findOne({ commitment: normalized }).exec();
   if (existing) {
     return existing._id!;
   }
 
   const commitmentRecord = await PaymentCommitmentModel.create({
-    commitment,
+    commitment: normalized,
     sourceType,
     createdAt: new Date(),
   });


### PR DESCRIPTION
## Summary

Implements fix 1 from holonym-foundation/internal-docs#236: `GET /payments/status` reported genuinely **redeemed** payments as `"unredeemed"` when the commitment query param used non-lowercase hex — the on-chain lookup parses hex case-insensitively, but `PaymentCommitmentModel.findOne({ commitment })` is a case-sensitive string match against the stored lowercase value. Support relied on that false `"unredeemed"` status and refunded already-redeemed payments. Notably, the `humanid status <commitment>` CLI (`packages/sdk/src/bin/humanid.ts`) passes the commitment from argv straight through and surfaces the response verbatim — likely how support hit this — so it now gets both correct statuses for any casing and a self-explanatory 400 for malformed input.

## Changes

- **New `normalizeCommitment()` helper** (`src/services/payments/commitment.ts`, a side-effect-free module re-exported from `payments/functions.ts`): validates a `0x`-prefixed 32-byte hex string and returns it lowercased; returns `null` for anything else (no trimming, no repair). Invalid input now gets a 400 with a consistent message instead of reaching the chain/DB.
- Applied at every endpoint accepting a client-supplied commitment (verified by grep to be exactly these four; all other flows derive the commitment server-side from the secret):
  - `GET /payments/status` — the reported bug; shared handler covers live + sandbox routes. This also fixes the same-root-cause miss in `isRedemptionPending`/`isRefundPending`, whose Valkey keys interpolate the commitment string — an uppercase query previously reported `"unredeemed"` for payments that were mid-redemption or mid-refund, too.
  - `GET /payments/payment-params` — live + sandbox. Safe for signatures: the commitment is ABI-encoded as `bytes32`, so case never reached the signed digest; normalization just makes the logged/signed value byte-identical to what redemption later derives.
  - `PUT /payment-secrets` — live + sandbox; this was the only path that persisted a client-supplied commitment verbatim (previously validated only as a truthy string). Normalization runs after the existing arg validation to preserve error precedence, and the rejection log records only the raw value's type/length (a client transposing the commitment and secret fields would otherwise land a payment secret in logs).
  - `POST /admin/payments/refund` — replaces the inline `toLowerCase()` from #74 with strict validation.
- **Defense in depth:** `createCommitmentRecord` (now in `commitment.ts`) normalizes and throws on malformed input, so a non-lowercase commitment can never be persisted (a case variant would silently bypass the case-sensitive unique index on `commitment`). The unused near-duplicate `createCommitmentRecord`/`getCommitmentRecord` pair in `human-id-credits/functions.ts` had no importers (the credits batch write is inline in `generatePaymentSecretsBatch` and derives its commitment locally) and is deleted.
- **`getRedemptionRecord` hardening:** its `$match` now lowercases the input. Redemptions only ever attach to lowercase commitment rows, so a legacy mixed-case row reaching it (e.g. via `GET /payment-secrets?checkRedemption=true`) would have missed its redemption and handed the user a spent secret — the issue-236 symptom via a different endpoint — even before the pre-deploy audit/migration runs.

**Deliberately untouched:** payment *secrets* are never case-normalized — commitments are keccak256 of the secret's exact UTF-8 string, so changing a secret's case would change its digest. `git diff` contains no changes to `/payments/refund/request` or redemption endpoints.

## Behavior changes

- Malformed commitments (wrong length, missing `0x`, non-hex) now get **400** at the boundary instead of, e.g., a 404 "Payment not found onchain" after a chain call.
- `PUT /payment-secrets` now requires the commitment to be a well-formed bytes32 hex string (previously any non-empty string was accepted). The frontend always sends `deriveCommitmentFromSecret` output, which satisfies this.
- `POST /admin/payments/refund` echoes the lowercased commitment in its response.

## Testing

- Unit tests: `src/services/payments/commitment.test.ts` (14 tests) — `normalizeCommitment` identity/normalization/rejection cases including the exact issue-236 uppercased-commitment scenario, plus stub-model coverage of `createCommitmentRecord` (throws before touching the model on malformed input, queries and persists lowercased, short-circuits on existing records).
- `bun test`: 116 pass, 1 skip, 2 fail — the 2 failures are pre-existing on `dev` (env-dependent `HOLONYM_ISSUER_PRIVKEY` assertion in `src/init.ts`, reproduced identically on a clean `dev` checkout).
- `tsc --noEmit` clean.

## Pre-deploy note

Before/at deploy, run a read-only audit for any existing non-lowercase rows (possible only via past `PUT /payment-secrets` calls):

```js
db.paymentcommitments.find({ commitment: /[A-F]/ }).count()
db.sandboxpaymentcommitments.find({ commitment: /[A-F]/ }).count()
db.paymentcommitments.find({ commitment: { $not: /^0x[0-9a-f]{64}$/ } }).count()
```

If any are found, check for a lowercase twin before lowercasing in place (the unique index will fail loudly on twins; twins need a manual merge of `commitmentId` references and should be flagged to support).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KfyYVw8XgmJQHFSKxkyFSV