### PR TITLE
fix(payments): distinguish "no commitment record" from "unredeemed" in /payments/status

### DIFF
--- a/src/services/payments/endpoints.ts
+++ b/src/services/payments/endpoints.ts
@@ -9,6 +9,7 @@ import {
   isRefundPending,
   isRedemptionPending,
   isPaymentRedeemed,
+  findRedemptionRecord,
   deriveCommitmentFromSecret,
   reserveRedemption,
   completeRedemption,
@@ -375,6 +376,11 @@ async function requestRefundSandbox(req: Request, res: Response) {
  * collections but the same real chains, so a live payment queried through
  * /sandbox/payments/status looks like a genuine "unredeemed" payment. Labeling
  * the environment makes that mistake self-evident to whoever reads the response.
+ *
+ * Every 200 response also includes "commitmentRecordFound", which is false when
+ * the payment exists onchain but we have no PaymentCommitment record for it —
+ * the sandbox case above, or a commitment queried with different hex casing. The
+ * status is then derived from onchain data alone and cannot rule out redemption.
  */
 function createPaymentStatusRouteHandler(config: SandboxVsLiveKYCRouteHandlerConfig) {
   return async (req: Request, res: Response) => {
@@ -409,29 +415,60 @@ function createPaymentStatusRouteHandler(config: SandboxVsLiveKYCRouteHandlerCon
         return res.status(404).json({ error: "Payment not found onchain", environment });
       }
 
+      const commitmentRecord = await config.PaymentCommitmentModel.findOne({ commitment }).exec();
+      // Every legitimate flow creates a PaymentCommitment (via PUT /payment-secrets) before the
+      // user pays, so a missing record means we cannot know whether this payment was redeemed --
+      // it is not evidence that the payment is unredeemed. Report it on every response so that
+      // callers (e.g. support checking before a refund) can tell the two apart.
+      const commitmentRecordFound = commitmentRecord !== null;
+
       if (payment.refunded) {
-        return res.status(200).json({ status: "refunded", payment, environment })
+        return res
+          .status(200)
+          .json({ status: "refunded", commitmentRecordFound, payment, environment })
       }
 
-      const commitmentRecord = await config.PaymentCommitmentModel.findOne({ commitment }).exec();
-
       // Check if already redeemed
-      if (await isPaymentRedeemed(commitmentRecord, config.PaymentRedemptionModel)) {
-        return res.status(200).json({ status: "redeemed", payment, environment });
+      const redemptionRecord = await findRedemptionRecord(commitmentRecord, config.PaymentRedemptionModel);
+      if (redemptionRecord) {
+        return res.status(200).json({
+          status: "redeemed",
+          commitmentRecordFound,
+          payment,
+          redemption: {
+            redeemedAt: redemptionRecord.redeemedAt ?? null,
+            service: redemptionRecord.service ?? null,
+            fulfillmentReceipt: redemptionRecord.fulfillmentReceipt ?? null,
+          },
+          environment,
+        });
       }
 
       // Check if redemption is pending
       if (await isRedemptionPending(commitment, config.environment)) {
-        return res.status(200).json({ status: "pending-redemption", payment, environment });
+        return res
+          .status(200)
+          .json({ status: "pending-redemption", commitmentRecordFound, payment, environment });
       }
 
       // Check if refund is pending
       if (await isRefundPending(commitment, config.environment)) {
-        return res.status(200).json({ status: "pending-refund", payment, environment });
+        return res
+          .status(200)
+          .json({ status: "pending-refund", commitmentRecordFound, payment, environment });
+      }
+
+      if (!commitmentRecordFound) {
+        paymentsLogger.warn(
+          { commitment, chainId: chainIdNum, environment },
+          "Payment exists onchain but has no PaymentCommitment record"
+        );
       }
 
       // Payment exists but no redemption or pending operations
-      return res.status(200).json({ status: "unredeemed", payment, environment });
+      return res
+        .status(200)
+        .json({ status: "unredeemed", commitmentRecordFound, payment, environment });
     } catch (error: any) {
       paymentsLogger.error({ error: error.message, environment }, "Error checking payment status");
       return res

--- a/src/services/payments/functions.ts
+++ b/src/services/payments/functions.ts
@@ -358,6 +358,26 @@ export async function getRedemptionRecord(
 }
 
 /**
+ * Find the redemption record for a commitment record, if the payment has been redeemed.
+ * Returns the document (not just a boolean) so callers can surface details such as
+ * service and fulfillmentReceipt.
+ */
+export async function findRedemptionRecord(
+  commitmentRecord: HydratedDocument<IPaymentCommitment> | null,
+  PaymentRedemptionModel: any
+): Promise<IPaymentRedemption | null> {
+  if (!commitmentRecord || !commitmentRecord._id) {
+    return null;
+  }
+
+  // Query PaymentRedemption by commitmentId
+  return await PaymentRedemptionModel.findOne({
+    commitmentId: commitmentRecord._id,
+    redeemedAt: { $exists: true, $ne: null }
+  }).exec();
+}
+
+/**
  * Check if payment is redeemed
  * Uses PaymentCommitment collection to look up commitmentId, then queries PaymentRedemption
  */
@@ -365,16 +385,8 @@ export async function isPaymentRedeemed(
   commitmentRecord: HydratedDocument<IPaymentCommitment> | null,
   PaymentRedemptionModel: any
 ): Promise<boolean> {
-  if (!commitmentRecord || !commitmentRecord._id) {
-    return false;
-  }
+  const redemption = await findRedemptionRecord(commitmentRecord, PaymentRedemptionModel);
 
-  // Query PaymentRedemption by commitmentId
-  const redemption = await PaymentRedemptionModel.findOne({ 
-    commitmentId: commitmentRecord._id,
-    redeemedAt: { $exists: true, $ne: null }
-  }).exec();
-  
   return redemption !== null;
 }
 


### PR DESCRIPTION
Implements **fix 2** from holonym-foundation/internal-docs#236.

## The problem

`GET /payments/status` reads the payment **onchain** (case-insensitive hex parse — always finds it) but reads the redemption from **Mongo** via a case-sensitive `PaymentCommitmentModel.findOne({ commitment })` against a stored lowercase string. When that DB lookup misses, `isPaymentRedeemed(null)` returns `false` and the handler falls through to a plain `"unredeemed"` — attached to real onchain payment details that make the answer look authoritative.

Two ways to trigger it, both reproduced live against the incident's commitments:

1. The `commitment` query param differs in hex case from the stored value.
2. The request hits `/sandbox/payments/status`, which reads sandbox collections against the same real chain.

In the incident, support's Postman check returned `unredeemed` for three payments that had all been redeemed and fulfilled (id-server logs show `Reserved redemption` + `Completed redemption` for each, seconds after session creation). Two of the three were force-refunded on the strength of that answer.

Every legitimate flow creates a `PaymentCommitment` via `PUT /payment-secrets` **before** the user pays, so "payment exists onchain but no commitment record" is an anomaly — it means we cannot know whether the payment was redeemed, not that it wasn't.

## The change

- All five `200` responses now carry **`commitmentRecordFound: boolean`**.
- The `PaymentCommitmentModel.findOne` lookup moved above the `payment.refunded` early return so the flag is present on every response. No status outcome changes; it adds one indexed query on the `refunded` path.
- The `"redeemed"` response is enriched with **`redemption: { redeemedAt, service, fulfillmentReceipt }`**, so support can see which session consumed the payment (also covers the ticket's ask to surface the `service` field without decoding calldata).
- A `warn` is logged on the `unredeemed`-with-no-record path. The endpoint logged nothing on success before, which is why the incident left no trace of what support actually queried.
- `findRedemptionRecord()` extracted in `functions.ts` (returns the document instead of a boolean); `isPaymentRedeemed()` is reimplemented on top of it, so every existing caller — `reserveRedemption`, `completeRedemption`, the refund paths — is behaviorally unchanged.

`getRedemptionRecord()` was deliberately **not** reused here: it takes the commitment string and re-runs an aggregation the handler doesn't need (it already holds the document), and its `$lookup` doesn't filter on `redeemedAt`, so it can return a redemption row that was never redeemed.

## Backward compatibility

No status value is added, renamed, or removed. This is deliberate: `VerificationPaymentGate` and `ChainAgnosticSBTPaymentGate` in the frontend **allowlist** the literal `'unredeemed'`, and `useHandlePayment` passes the server status through verbatim — a new status value like `"unredeemed-no-commitment-record"` would silently trap real users at the paywall. The added fields are inert to the frontend, the SDK CLI (`checkPaymentStatus` reads `status` only), and the Rust clean-hands-observer (serde ignores unknown fields).

## Verification

Local Mongo/Valkey weren't available, so the real exported `paymentStatusProd` handler was driven through a harness faking only the chain read, Valkey, and the two Mongo models:

| case | response |
|---|---|
| redeemed, lowercase commitment | `redeemed`, `commitmentRecordFound: true`, `redemption: {redeemedAt, service, fulfillmentReceipt: "gov-id-session:…"}`, `environment: "live"` |
| **same redeemed payment, uppercase commitment (the incident)** | `unredeemed`, `commitmentRecordFound: false`, one WARN |
| genuinely unredeemed (record exists, no redemption) | `unredeemed`, `commitmentRecordFound: true`, no WARN |
| pending-redemption / pending-refund | status unchanged, flag added |
| refunded, with and without record | status unchanged, flag added |

`bun run check:types` exits 0. `bun test`: 102 pass / 2 fail — identical to unmodified `dev`, so those failures are pre-existing.

Worth re-checking on a staging/prod-pointed instance with a real commitment before merge, since the harness fakes the Mongo layer.

## Rebased onto #74 and #75

Rebased after #75 (fix 3, `environment` label) and #74 (fix 4, admin force-refund guard) merged. #75 touches this same handler, so the conflict was resolved by keeping both: every 200 response now carries `commitmentRecordFound` **and** `environment`, and the anomaly warn reuses #75's `environment` local. Harness and typecheck re-run after the rebase; the verification table above reflects the merged handler.

## Still outstanding from internal-docs#236

Not in this PR: fix 1 (normalize commitments at every API boundary — the actual root cause of the case-mismatch miss) and fix 5 (the orphaned-session / `markPaymentAsRedeemed`-throws hole). Fixes 3 and 4 landed in #75 and #74.

Minor follow-up this PR enables: `src/services/admin/refund-payment.ts` (from #74) calls `isPaymentRedeemed` and then `getRedemptionRecord`, two queries for one answer. It could use the `findRedemptionRecord` helper added here and do it in one. Left alone to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKByQEDQw1fusJDVmxZxGK
