### PR TITLE
fix(admin-refund): check both environments and widen the audit trail (follow-up to #74)

### DIFF
--- a/src/services/admin/refund-payment.ts
+++ b/src/services/admin/refund-payment.ts
@@ -3,9 +3,11 @@ import {
   forceRefundPayment,
   getRedemptionRecord,
   isPaymentRedeemed,
+  isRedemptionPending,
 } from "../payments/functions.js";
 import { pinoOptions, logger } from "../../utils/logger.js";
 import { getRouteHandlerConfig } from "../../init.js";
+import { SandboxVsLiveKYCRouteHandlerConfig } from "../../types.js";
 
 const adminRefundPaymentLogger = logger.child({
   base: {
@@ -14,6 +16,65 @@ const adminRefundPaymentLogger = logger.child({
     subFeature: "admin-refund-payment",
   },
 });
+
+type RedemptionInspection = {
+  environment: "sandbox" | "live";
+  commitmentRecordFound: boolean;
+  redeemed: boolean;
+  service?: string;
+  fulfillmentReceipt?: string;
+  redeemedAt?: Date;
+};
+
+/**
+ * Look up a commitment's redemption state in one environment.
+ *
+ * `isPaymentRedeemed` is the canonical predicate (it requires `redeemedAt` to
+ * be set); `getRedemptionRecord` is only consulted for the operator-facing
+ * details, and only once the predicate has already said "redeemed", so the two
+ * cannot report different answers.
+ */
+async function inspectRedemption(
+  config: SandboxVsLiveKYCRouteHandlerConfig,
+  commitment: string
+): Promise<RedemptionInspection> {
+  const commitmentRecord = await config.PaymentCommitmentModel.findOne({
+    commitment,
+  }).exec();
+  const redeemed = await isPaymentRedeemed(
+    commitmentRecord,
+    config.PaymentRedemptionModel
+  );
+
+  const inspection: RedemptionInspection = {
+    environment: config.environment,
+    commitmentRecordFound: commitmentRecord !== null,
+    redeemed,
+  };
+
+  if (!redeemed) return inspection;
+
+  const redemption = await getRedemptionRecord(
+    commitment,
+    config.PaymentRedemptionModel,
+    config.PaymentCommitmentModel
+  );
+  inspection.service = redemption?.service;
+  inspection.fulfillmentReceipt = redemption?.fulfillmentReceipt;
+  inspection.redeemedAt = redemption?.redeemedAt;
+  return inspection;
+}
+
+function describeRedemption(inspection: RedemptionInspection): string {
+  const details = [
+    `environment: ${inspection.environment}`,
+    inspection.service ? `service: ${inspection.service}` : null,
+    inspection.fulfillmentReceipt
+      ? `fulfillment receipt: ${inspection.fulfillmentReceipt}`
+      : null,
+  ].filter(Boolean);
+  return details.join(", ");
+}
 
 /**
  * POST /admin/payments/refund
@@ -28,10 +89,17 @@ const adminRefundPaymentLogger = logger.child({
  * deliberate act rather than the default. Support refunded two fulfilled
  * payments in the incident tracked by internal-docs#236 because nothing on
  * this path flagged them as redeemed.
+ *
+ * The check covers both environments. Payment contracts are keyed by chain
+ * only (`humanIDPaymentsContractAddresses`), so a sandbox-redeemed payment
+ * sits on the same real chain and is just as refundable here, but its
+ * redemption lives in the Sandbox* collections — checking only "live" would
+ * miss it. That was the other half of the #236 read-path confusion.
  */
 export async function refundPayment(req: Request, res: Response) {
   try {
     const liveConfig = getRouteHandlerConfig("live");
+    const sandboxConfig = getRouteHandlerConfig("sandbox");
 
     const { commitment, chainId, allowRedeemed } = req.body;
 
@@ -54,50 +122,76 @@ export async function refundPayment(req: Request, res: Response) {
       return res.status(400).json({ error: "chainId must be a number" });
     }
 
-    // Commitment records are stored lowercase, and the Mongo lookup is a
-    // case-sensitive string match, so an uppercase commitment would silently
-    // miss the record and make the payment look unredeemed.
+    // Every commitment we write today is lowercase (ethers-derived, or a
+    // client-supplied string that must match one to be redeemable), while the
+    // Mongo lookup is a case-sensitive string match — so lowercasing the input
+    // is what makes an uppercase commitment find its record instead of looking
+    // unredeemed. Note the schema does not enforce lowercase storage, so this
+    // does not help if a record was somehow stored uppercase; normalizing at
+    // every commitment boundary (fix 1 of internal-docs#236) is what would.
     const normalizedCommitment = commitment.toLowerCase();
 
-    const commitmentRecord = await liveConfig.PaymentCommitmentModel.findOne({
-      commitment: normalizedCommitment,
-    }).exec();
-    const redeemed = await isPaymentRedeemed(
-      commitmentRecord,
-      liveConfig.PaymentRedemptionModel
-    );
+    const inspections = await Promise.all([
+      inspectRedemption(liveConfig, normalizedCommitment),
+      inspectRedemption(sandboxConfig, normalizedCommitment),
+    ]);
+    const redeemedIn = inspections.filter((i) => i.redeemed);
+    const redeemed = redeemedIn.length > 0;
+    const commitmentRecordFound = inspections.some((i) => i.commitmentRecordFound);
     const overrideRequested = allowRedeemed === true || allowRedeemed === "true";
 
+    const auditBase = {
+      commitment: normalizedCommitment,
+      chainId: chainIdNum,
+      redeemed,
+      redeemedIn: redeemedIn.map((i) => i.environment),
+      commitmentRecordFound,
+      fulfillmentReceipts: redeemedIn.map((i) => i.fulfillmentReceipt),
+    };
+
     if (redeemed && !overrideRequested) {
-      const redemption = await getRedemptionRecord(
-        normalizedCommitment,
-        liveConfig.PaymentRedemptionModel,
-        liveConfig.PaymentCommitmentModel
-      );
       adminRefundPaymentLogger.info(
-        {
-          commitment: normalizedCommitment,
-          chainId: chainIdNum,
-          fulfillmentReceipt: redemption?.fulfillmentReceipt,
-          service: redemption?.service,
-          redeemedAt: redemption?.redeemedAt,
-        },
+        auditBase,
         "Admin force-refund rejected: payment has already been redeemed"
       );
       return res.status(400).json({
         error:
-          "Payment has already been redeemed" +
-          (redemption?.fulfillmentReceipt
-            ? ` (fulfillment receipt: ${redemption.fulfillmentReceipt})`
-            : "") +
-          ". Verify the service was actually not delivered, then retry with " +
+          `Payment has already been redeemed (${redeemedIn.map(describeRedemption).join("; ")}). ` +
+          "Verify the service was actually not delivered, then retry with " +
           '"allowRedeemed": true to refund anyway.',
-        redemption: {
-          service: redemption?.service,
-          fulfillmentReceipt: redemption?.fulfillmentReceipt,
-          redeemedAt: redemption?.redeemedAt,
-        },
+        redemptions: redeemedIn.map((i) => ({
+          environment: i.environment,
+          service: i.service,
+          fulfillmentReceipt: i.fulfillmentReceipt,
+          redeemedAt: i.redeemedAt,
+        })),
       });
+    }
+
+    // A redemption in flight in either environment must also block the refund.
+    // `forceRefundPayment` only checks the environment it is given, and the
+    // pending keys are environment-prefixed.
+    if (await isRedemptionPending(normalizedCommitment, "sandbox")) {
+      adminRefundPaymentLogger.info(
+        auditBase,
+        "Admin force-refund rejected: redemption is pending in the sandbox environment"
+      );
+      return res.status(400).json({
+        error: "Redemption is pending for this payment in the sandbox environment",
+      });
+    }
+
+    // No commitment record in either environment is not the same as "not
+    // redeemed" — it can also mean the bookkeeping row was never written (e.g.
+    // a failed PUT /payment-secrets), in which case a delivered service would
+    // leave no redemption to find. Refunding is still the common, correct
+    // action here, but the audit trail has to be able to tell the two apart.
+    if (!commitmentRecordFound) {
+      adminRefundPaymentLogger.warn(
+        auditBase,
+        "Admin force-refund: no PaymentCommitment record in either environment; " +
+          "redemption state is unknown, not confirmed-unredeemed"
+      );
     }
 
     const result = await forceRefundPayment(normalizedCommitment, chainIdNum, {
@@ -105,21 +199,30 @@ export async function refundPayment(req: Request, res: Response) {
       environment: liveConfig.environment,
     });
 
+    const overrideUsed = redeemed && overrideRequested;
+
     if (!result.success) {
+      adminRefundPaymentLogger.error(
+        { ...auditBase, overrideUsed, status: result.status, error: result.error },
+        "Admin force-refund failed"
+      );
       return res.status(result.status).json({ error: result.error });
     }
 
-    adminRefundPaymentLogger.info(
-      {
-        commitment: normalizedCommitment,
-        chainId: chainIdNum,
-        contractAddress: result.contractAddress,
-        txHash: result.txHash,
-        redeemed,
-        overrideUsed: redeemed && overrideRequested,
-      },
-      "Admin force-refund completed"
-    );
+    const successPayload = {
+      ...auditBase,
+      overrideUsed,
+      contractAddress: result.contractAddress,
+      txHash: result.txHash,
+    };
+    if (overrideUsed) {
+      adminRefundPaymentLogger.warn(
+        successPayload,
+        "Admin force-refund completed on an already-redeemed payment (override used)"
+      );
+    } else {
+      adminRefundPaymentLogger.info(successPayload, "Admin force-refund completed");
+    }
 
     return res.status(200).json({
       message: "Refund processed successfully",
@@ -128,6 +231,9 @@ export async function refundPayment(req: Request, res: Response) {
       contractAddress: result.contractAddress,
       txHash: result.txHash,
       redeemed,
+      redeemedIn: redeemedIn.map((i) => i.environment),
+      commitmentRecordFound,
+      overrideUsed,
     });
   } catch (error: any) {
     adminRefundPaymentLogger.error({ error: error.message }, "Error processing admin refund");


### PR DESCRIPTION
Follow-up to #74. That PR was merged before this commit was pushed, so the entire review round landed nowhere — `dev` currently has only the first commit (`4f318fc`). This is that commit (`53ec666`) cherry-picked onto current `dev`, file-identical to what was reviewed.

Review thread: https://github.com/holonym-foundation/id-server/pull/74#issuecomment-5167911864

## What's in here

- **Check both environments (the blocking finding).** `getRouteHandlerConfig("sandbox")` returns the `Sandbox*` collections (init.ts:745-747) while `humanIDPaymentsContractAddresses` (constants/misc.ts:164) is keyed by chain alone — so a sandbox-redeemed payment sits on the same real contract and is just as refundable here, but its redemption record is invisible to a live-only lookup. Since `/sandbox/payments/status` reading sandbox collections against live chains is one of the two ways internal-docs#236 produced a misleading `unredeemed`, the merged guard covers only one of the two paths that caused the incident. Now both configs are checked and the rejection names the environment.
- **Sandbox pending redemptions too.** `forceRefundPayment` only checks `isRedemptionPending` for the environment it's handed and the pending valkey keys are `sandbox:`-prefixed, so a sandbox redemption *in flight* was invisible for the same reason.
- **`commitmentRecordFound` in the audit trail.** `isPaymentRedeemed(null)` returns false (functions.ts:368-370), so "no bookkeeping row" was indistinguishable from "genuinely unredeemed" in the logs — including for the orphaned-session state fix 5 describes. Now logged, at `warn` when absent from both environments, worded as *unknown* rather than confirmed-unredeemed, and returned in the response. It does **not** require the override: "user paid, `PUT /payment-secrets` never landed, refund them" is this endpoint's most common legitimate case, and gating it behind a flag named `allowRedeemed` would train operators to set that flag by default, spending the signal it exists to carry.
- **Override-used refunds log at `warn`**, not buried at `info` with routine refunds; failed refunds now log at `error` with status and error, where previously they returned with no trace anyone had tried.
- **Lowercasing comment softened.** `PaymentCommitmentSchema.commitment` is a bare `String` with no `lowercase: true` (schemas.ts:1516-1521) and `payment-secrets.ts:66` passes the raw body value through, so the comment now describes what's true today and points at fix 1 for real normalization instead of asserting an invariant the schema doesn't hold.
- **Single canonical predicate.** `getRedemptionRecord` is only called once `isPaymentRedeemed` has returned true, so the two can't disagree; the extra query happens on the reject path only.

## API impact beyond #74

The 400 body now returns `redemptions[]` (an array, each entry carrying `environment`) instead of a single `redemption` object, and the 200 body gains `redeemedIn`, `commitmentRecordFound` and `overrideUsed`.

## Testing

`tsc --noEmit` passes on top of current `dev`. `bun test` matches the base commit (102 pass / 2 fail / 2 errors — pre-existing `validateEnv()` env-var failures).
